### PR TITLE
Additional flags for suppressing warnings.

### DIFF
--- a/nvblox/CMakeLists.txt
+++ b/nvblox/CMakeLists.txt
@@ -23,12 +23,17 @@ option(BUILD_TESTS "Build the C++ tests of the nvblox library" ON)
 # "display_error_number" shows a warning number with all warnings, and the
 # rest is just suppressing specific warnings from Eigen. Note that the numbers
 # keep changing with every CUDA release so this list is a bit arbitrary.
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr  --generate-line-info -lineinfo -Xcudafe --display_error_number -Xcudafe --diag_suppress=2977  -Xcudafe --diag_suppress=3057  -Xcudafe --diag_suppress=3059 ")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr  --generate-line-info -lineinfo \
+                        -Xcudafe --display_error_number -Xcudafe --diag_suppress=2977  \
+                        -Xcudafe --diag_suppress=3057  -Xcudafe --diag_suppress=3059 \
+                        -Xcudafe --diag_suppress=20091 -Xcudafe --diag_suppress=20012  \
+                        -Xcudafe --diag_suppress=20054   -Xcudafe --diag_suppress=20236")
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --compiler-options -fPIC")
 
 # New warning numbers above CUDA 11.2.
 if (CUDA_VERSION_MAJOR EQUAL 11 AND CUDA_VERSION_MINOR GREATER_EQUAL 2)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=20012 -Xcudafe --diag_suppress=20011 -Xcudafe --diag_suppress=20014")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=20012 \
+                            -Xcudafe --diag_suppress=20011 -Xcudafe --diag_suppress=20014")
 endif()
 
 # Download thirdparty deps
@@ -178,7 +183,8 @@ target_link_libraries(nvblox_interface INTERFACE
     Eigen3::Eigen
     gflags
 )
-target_include_directories(nvblox_interface INTERFACE include ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+target_include_directories(nvblox_interface INTERFACE
+                            include ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 
 ##########
 # EXPORT #


### PR DESCRIPTION
Adding additional compiler flags to suppress warnings during colcon build in ROS2 environment.