### PR TITLE
Add explicit include for std::function in rates.h

### DIFF
--- a/nvblox/include/nvblox/utils/rates.h
+++ b/nvblox/include/nvblox/utils/rates.h
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #pragma once
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
It fails in my computer (Ubuntu 22.04 + CUDA 12.6.85 + GCC 12.3.0):
```
nvblox/nvblox/include/nvblox/utils/rates.h:71:34: error: ‘function’ in namespace ‘std’ does not name a template type
   71 | using GetTimestampFunctor = std::function<int64_t()>;
```