### PR TITLE
FIX: Wrap stdgpu target as nvblox_stdgpu

### DIFF
--- a/nvblox/CMakeLists.txt
+++ b/nvblox/CMakeLists.txt
@@ -59,7 +59,7 @@ add_nvblox_static_library(nvblox_gpu_hash
     src/gpu_hash/mesh_layer_specialization.cu
     src/gpu_hash/gpu_set.cu
   LINK_LIBRARIES_PUBLIC
-    stdgpu
+    nvblox_stdgpu
     nvblox_eigen
   LINK_LIBRARIES_PRIVATE
     glog::glog
@@ -208,4 +208,4 @@ install(
     PATTERN "*/unsupported**" EXCLUDE
 )
 install(DIRECTORY ${ext_stdgpu_SOURCE_DIR}/src/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stdgpu)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/nvblox/CMakeLists.txt
+++ b/nvblox/CMakeLists.txt
@@ -207,5 +207,5 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     PATTERN "*/unsupported**" EXCLUDE
 )
-install(DIRECTORY ${ext_stdgpu_SOURCE_DIR}/include/
+install(DIRECTORY ${ext_stdgpu_SOURCE_DIR}/src/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stdgpu)

--- a/nvblox/CMakeLists.txt
+++ b/nvblox/CMakeLists.txt
@@ -186,7 +186,7 @@ include(GNUInstallDirs)
 set_target_properties(stdgpu PROPERTIES INTERFACE_LINK_LIBRARIES "")
 
 install(
-    TARGETS nvblox_lib nvblox_gpu_hash nvblox_datasets stdgpu nvblox_eigen fuse_3dmatch fuse_replica
+    TARGETS nvblox_lib nvblox_gpu_hash nvblox_datasets nvblox_stdgpu nvblox_eigen fuse_3dmatch fuse_replica
     EXPORT nvbloxTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -207,3 +207,5 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     PATTERN "*/unsupported**" EXCLUDE
 )
+install(DIRECTORY ${ext_stdgpu_SOURCE_DIR}/include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/stdgpu)

--- a/nvblox/thirdparty/stdgpu/stdgpu.cmake
+++ b/nvblox/thirdparty/stdgpu/stdgpu.cmake
@@ -39,4 +39,9 @@ FetchContent_MakeAvailable(ext_stdgpu)
 
 # Apply nvblox compile options to exported targets
 set_nvblox_compiler_options_nowarnings(stdgpu)
+add_library(nvblox_stdgpu INTERFACE)
+  target_link_libraries(nvblox_stdgpu INTERFACE stdgpu)
+  target_include_directories(nvblox_stdgpu INTERFACE
+    $<BUILD_INTERFACE:${ext_stdgpu_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/stdgpu>)
 endif()

--- a/nvblox/thirdparty/stdgpu/stdgpu.cmake
+++ b/nvblox/thirdparty/stdgpu/stdgpu.cmake
@@ -42,6 +42,6 @@ set_nvblox_compiler_options_nowarnings(stdgpu)
 add_library(nvblox_stdgpu INTERFACE)
   target_link_libraries(nvblox_stdgpu INTERFACE stdgpu)
   target_include_directories(nvblox_stdgpu INTERFACE
-    $<BUILD_INTERFACE:${ext_stdgpu_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${ext_stdgpu_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:include/stdgpu>)
 endif()


### PR DESCRIPTION
## Summary
Warp stdgpu target as nvblox_stdgpu

## Detailed description
- What was the reason for the change?
The nvblox package cannot be built above cmake 3.22.
- What has been changed?
aded a nvblox_stdgpu interface target to properly encapsulate the stdgpu dependency and ensures its headers are correctly installed
- What is the impact of this change?
This commit resolve the cmake issue for cmake version greater than 3.22
Related Issue: https://github.com/nvidia-isaac/nvblox/issues/65 and https://github.com/nvidia-isaac/nvblox/issues/54