### PR TITLE
FIX: include paths of stdgpu after install

### DIFF
--- a/nvblox/thirdparty/stdgpu/stdgpu.cmake
+++ b/nvblox/thirdparty/stdgpu/stdgpu.cmake
@@ -43,5 +43,5 @@ add_library(nvblox_stdgpu INTERFACE)
   target_link_libraries(nvblox_stdgpu INTERFACE stdgpu)
   target_include_directories(nvblox_stdgpu INTERFACE
     $<BUILD_INTERFACE:${ext_stdgpu_SOURCE_DIR}/src>
-    $<INSTALL_INTERFACE:include/stdgpu>)
+    $<INSTALL_INTERFACE:include>)
 endif()


### PR DESCRIPTION
The fix introduced in #69 (https://github.com/nvidia-isaac/nvblox/pull/69) broke the usage of nvblox in other CMake projects. 

The include paths of stdgpu were incorrectly mapped to `/usr/local/include/stdgpu` instead of the correct `/usr/local/include`. 
These lead to a variety of errors in other projects. Most notably, stdgpu has a `limits.h` header that subsequently clashes with the standard C `limits.h` header, leading to undefined symbols.  

To reproduce the error, build and install nvblox using make, and then use it in any other CMake project. 

**This pull request only resets to the correct stdgpu include path.**

Tested and verified on my setup:
* Ubuntu 22.04. (running in WSL2 on Windows 11), 
* CUDA (Toolkit) 12.8,
* gcc 11.4, and 
* CMake 3.22.1.