### PR TITLE
Add host & device support for casting nvblox time.

### DIFF
--- a/nvblox/include/nvblox/core/time.h
+++ b/nvblox/include/nvblox/core/time.h
@@ -28,7 +28,7 @@ class Time {
   constexpr Time() : time_(0UL) {}
 
   // Conversion operator to int64_t
-  explicit operator int64_t() const { return time_; }
+  explicit __host__ __device__ operator int64_t() const { return time_; }
   // Heaps of (trivial) operator overloading
   __host__ __device__ bool operator==(const Time& other) const {
     return time_ == other.time_;


### PR DESCRIPTION
- Adds host & device support for casting nvblox time (previously was just only supported on host).
- Afterwards, are able to cast to `std::int64_t` on the device.