### PR TITLE
Fix dynamic masked value to be the masked pixel value.

### DIFF
--- a/nvblox/src/dynamics/dynamics_detection.cu
+++ b/nvblox/src/dynamics/dynamics_detection.cu
@@ -74,7 +74,7 @@ __global__ void findDynamicPointsKernel(
   }
 
   // Update mask and overlay image
-  image::access(row_idx, col_idx, cols, dynamic_mask_image) = is_dynamic;
+  image::access(row_idx, col_idx, cols, dynamic_mask_image) = is_dynamic * image::kMaskedValue;
   image::access(row_idx, col_idx, cols, dynamic_overlay_image) =
       getOverlayColor(is_dynamic, depth);
 }


### PR DESCRIPTION
- Previously, dynamic mask pixels were set to the "is_dynamic" boolean (implicitly casted to uint8_t). Here we instead set it to the constant kMaskedValue to be consistent with other masking operations.
- This makes it easier to work with masking functionality more consistently when using nvblox.