### PR TITLE
Fix for User/Group Creation Issue

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -55,6 +55,7 @@ then
 
     # Re-add the user
     userdel "$DOCKER_RUN_USER_NAME" || true
+    groupadd --force --gid "$DOCKER_RUN_GROUP_ID" "$DOCKER_RUN_GROUP_NAME"
     if id $DOCKER_RUN_USER_ID; then
         echo "User $DOCKER_RUN_USER_NAME with $DOCKER_RUN_USER_ID already exists."
         EXISTING_USER_NAME=$(id -nu $DOCKER_RUN_USER_ID)


### PR DESCRIPTION
**Fix for User/Group Creation Bug**

The script sometimes failed when attempting to re-create the host user (e.g., ubuntu with UID 1000) inside the container.

Problem: The userdel "$DOCKER_RUN_USER_NAME" command, intended for cleanup, occasionally deleted the corresponding primary group ($DOCKER_RUN_GROUP_NAME) if the user was its sole member. This caused the subsequent useradd command to fail with useradd: group 'ubuntu' does not exist.

Fix: A necessary, idempotent groupadd --force call is re-inserted immediately after the userdel operation. This ensures the target group is immediately restored and confirmed to exist just before the final useradd attempt.