### PR TITLE
Fix bug where SphereTracer's max ray length was not updated.

### DIFF
--- a/nvblox/include/nvblox/integrators/internal/projective_integrator.h
+++ b/nvblox/include/nvblox/integrators/internal/projective_integrator.h
@@ -77,7 +77,7 @@ class ProjectiveIntegrator {
   /// See max_integration_distance_m().
   /// @param max_integration_distance_m the maximum integration distance in
   /// meters.
-  void max_integration_distance_m(float max_integration_distance_m);
+  virtual void max_integration_distance_m(float max_integration_distance_m);
 
   /// Returns the object used to calculate the blocks in camera views.
   const ViewCalculator& view_calculator() const;

--- a/nvblox/include/nvblox/integrators/projective_appearance_integrator.h
+++ b/nvblox/include/nvblox/integrators/projective_appearance_integrator.h
@@ -107,6 +107,12 @@ class ProjectiveAppearanceIntegrator
   /// @return The truncation distance
   float get_truncation_distance_m(float voxel_size) const;
 
+  /// A parameter setter which additionally updates the sphere tracer's maximum
+  /// ray length. See max_integration_distance_m().
+  /// @param max_integration_distance_m the maximum integration distance in
+  /// meters.
+  void max_integration_distance_m(float max_integration_distance_m) override;
+
   /// A parameter setter
   /// See max_weight().
   /// @param max_weight the maximum weight of a voxel.

--- a/nvblox/src/integrators/projective_appearance_integrator.cu
+++ b/nvblox/src/integrators/projective_appearance_integrator.cu
@@ -57,9 +57,7 @@ ProjectiveAppearanceIntegrator<LayerType>::ProjectiveAppearanceIntegrator(
       update_functor_host_ptr_(
           make_unified<UpdateAppearanceVoxelFunctor<VoxelType>>(
               MemoryType::kHost)),
-      sphere_tracer_(cuda_stream) {
-  sphere_tracer_.maximum_ray_length_m(this->max_integration_distance_m_);
-}
+      sphere_tracer_(cuda_stream) {}
 
 // NOTE(dtingdahl): We can't default this in the header file because to the
 // unified_ptr to a forward declared type. The type has to be defined where
@@ -212,6 +210,14 @@ template <class LayerType>
 float ProjectiveAppearanceIntegrator<LayerType>::get_truncation_distance_m(
     float voxel_size) const {
   return this->truncation_distance_vox_ * voxel_size;
+}
+
+template <class LayerType>
+void ProjectiveAppearanceIntegrator<LayerType>::max_integration_distance_m(
+    float max_integration_distance_m) {
+  ProjectiveIntegrator<VoxelType>::max_integration_distance_m(
+      max_integration_distance_m);
+  sphere_tracer_.maximum_ray_length_m(max_integration_distance_m);
 }
 
 template <class LayerType>


### PR DESCRIPTION
In `ProjectiveAppearanceIntegrator`, the `SphereTracer`'s max ray length was initialized once at construction to the value of `max_integration_distance_m_`. However, `max_integration_distance_m_` can be updated later via setter, which did not update the max ray length. 

Fix is by making the setter virtual and overriding in `ProjectiveAppearanceIntegrator`  to also set max ray length.

I think this might be the issue reported in #94.