### PR TITLE
Dtingdahl/v0.0.8 docs/fix multidoc version

### DIFF
--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -1,0 +1,21 @@
+{% if versions %}
+<nav class="bd-links bd-docs-nav">
+    <div class="bd-toc-item navbar-nav">
+      <ul class="nav bd-sidenav">
+        <li class="toctree-l1 has-children" style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
+          <div  style ="text-align:center;">
+            <label for="version-select" style="font-weight: bold; display: block;">Version</label>
+          </div>
+          <select id="version-select" class="version-dropdown" style="margin: 0 auto; display: block;" onchange="location = this.value;">
+            {%- for item in versions.branches %}
+            <option value="{{ item.url }}" {% if item == current_version %}selected{% endif %}>{{ item.name }}</option>
+            {%- endfor %}
+            {%- for item in versions.tags|reverse %}
+            <option value="{{ item.url }}" {% if item == current_version %}selected{% endif %}>{{ item.name }}</option>
+            {%- endfor %}
+          </select>
+        </li>
+      </ul>
+    </div>
+</nav>
+{% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,20 +17,88 @@ from typing import List
 import os
 import sys
 
-# Modify PYTHONPATH so we can import the helpers module.
-# pylint: disable=wrong-import-position
-sys.path.insert(0, os.path.abspath('.'))
-from helpers import get_version_from_multiversion_env
+# NOTE: sphinx-multiversion doesn't provide a reliable way to detect the version
+# at conf.py import time. We need to use the setup() function to access Sphinx config.
+# For now, set a placeholder that will be updated in setup().
+NVBLOX_VERSION_NUMBER = '0.0.8'    # Will be overridden in setup()
+NVBLOX_VERSION_PATCH = 'rc5'    # For v0.0.8
 
-# NOTE: We use environment variables instead of importing from setup.py to avoid
-# Python module import caching issues with sphinx-multiversion. When building
-# multiple versions, the first import of 'setup' gets cached and reused for all
-# subsequent builds. Reading from SPHINX_MULTIVERSION_NAME env var ensures each
-# version build uses its correct version number.
-NVBLOX_VERSION_NUMBER = get_version_from_multiversion_env()
 
-# For v0.0.8, the version patch is 'rc5'
-NVBLOX_VERSION_PATCH = 'rc5'
+# Define setup() function to properly detect version after Sphinx initializes
+# pylint: disable=import-outside-toplevel,broad-exception-caught
+def setup(app: object) -> None:
+    """Sphinx setup function to detect version from sphinx-multiversion context.
+
+    This function runs after Sphinx initializes and has access to app.srcdir,
+    which points to the correct source directory for each version being built.
+    """
+    import re
+    import subprocess
+
+    def _get_wheel_name(version: str, ubuntu: str, cuda: str) -> str:
+        """Generate wheel filename based on version."""
+        version_patches = {
+            '0.0.8': 'rc5',
+            '0.0.9': '.dev1',
+        }
+        patch = version_patches.get(version, '.dev1')
+        return f'nvblox_torch-{version}{patch}+cu{cuda}ubuntu{ubuntu}-863-py3-none-linux_x86_64.whl'
+
+    def _update_version_config(version: str) -> None:
+        """Update all version-dependent configuration values."""
+        global NVBLOX_VERSION_NUMBER
+        NVBLOX_VERSION_NUMBER = version
+        app.config.html_title = f'nvblox_torch {NVBLOX_VERSION_NUMBER}'
+
+        # Update wheel URLs and names in nvblox_torch_docs_config
+        app.config.nvblox_torch_docs_config['external_wheel_base_url'] = \
+            f'https://github.com/nvidia-isaac/nvblox/releases/download/v{version}'
+        app.config.nvblox_torch_docs_config['wheel_name_ubuntu_24_cuda_12'] = \
+            _get_wheel_name(version, '24', '12')
+        app.config.nvblox_torch_docs_config['wheel_name_ubuntu_22_cuda_12'] = \
+            _get_wheel_name(version, '22', '12')
+        app.config.nvblox_torch_docs_config['wheel_name_ubuntu_22_cuda_11'] = \
+            _get_wheel_name(version, '22', '11')
+        app.config.nvblox_torch_docs_config['wheel_name_ubuntu_24_cuda_13'] = \
+            _get_wheel_name(version, '24', '13')
+
+    # Try to get version from various sources
+    # 1. Check environment variable (sphinx-multiversion should set this)
+    smv_current_version = os.environ.get('SPHINX_MULTIVERSION_NAME')
+    if smv_current_version:
+        match = re.match(r'v?(\d+\.\d+\.\d+)', smv_current_version)
+        if match:
+            _update_version_config(match.group(1))
+            return
+
+    # 2. Try git in the source directory
+    try:
+        result = subprocess.run(['git', 'describe', '--all', '--exact-match', 'HEAD'],
+                                capture_output=True,
+                                text=True,
+                                cwd=app.srcdir,
+                                check=False)
+        if result.returncode == 0:
+            ref_name = result.stdout.strip()
+            match = re.search(r'v?(\d+\.\d+\.\d+)', ref_name)
+            if match:
+                _update_version_config(match.group(1))
+                return
+    except Exception:
+        pass    # Git detection failed, continue to fallback
+
+    # 3. Fallback: read from setup.py in the source directory
+    # This is the most reliable method for sphinx-multiversion builds
+    setup_path = os.path.join(app.srcdir, '..', 'nvblox_torch', 'setup.py')
+    try:
+        with open(setup_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        match = re.search(r"NVBLOX_VERSION_NUMBER\s*=\s*['\"]([^'\"]+)['\"]", content)
+        if match:
+            _update_version_config(match.group(1))
+    except Exception:
+        pass    # Use default version
+
 
 # NOTE(alexmillane, 2025-04-24): This file is in a seperate folder to avoid
 # duplicate configuration errors coming from mypy. The only way I could find

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import sys
 # Modify PYTHONPATH so we can obtain the version data from setup module.
 # pylint: disable=wrong-import-position
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'nvblox_torch')))
-from setup import NVBLOX_VERSION, NVBLOX_VERSION_NUMBER
+from setup import NVBLOX_VERSION_NUMBER, NVBLOX_VERSION_PATCH
 
 # NOTE(alexmillane, 2025-04-24): This file is in a seperate folder to avoid
 # duplicate configuration errors coming from mypy. The only way I could find
@@ -83,7 +83,7 @@ nitpick_ignore: List[str] = []    # can exclude known bad refs
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'nvidia_sphinx_theme'
-html_title = f'nvblox_torch {NVBLOX_VERSION_NUMBER}'
+html_title = 'nvblox'
 html_show_sphinx = False
 html_theme_options = {
     'copyright_override': {
@@ -124,19 +124,21 @@ linkcheck_ignore = [
 #####################################
 #  Macros dependent on release state
 #####################################
-
+# pylint: disable=line-too-long
 nvblox_torch_docs_config = {
     'released': released,
     'internal_wheel_base_url': 'https://urm.nvidia.com/artifactory/hw-nvblox-alpine-local/' + \
         'pypi/release/nvblox_torch/',
     'external_wheel_base_url': 'https://github.com/nvidia-isaac/nvblox/releases' + \
-        f'/download/v{NVBLOX_VERSION}',
+        f'/download/v{NVBLOX_VERSION_NUMBER}',
     'wheel_name_ubuntu_24_cuda_12': \
-        'nvblox_torch-0.0.8rc3+cu12ubuntu24-851-py3-none-linux_x86_64.whl',
+        f'nvblox_torch-{NVBLOX_VERSION_NUMBER}{NVBLOX_VERSION_PATCH}+cu12ubuntu24-863-py3-none-linux_x86_64.whl',
     'wheel_name_ubuntu_22_cuda_12': \
-        'nvblox_torch-0.0.8rc3+cu12ubuntu22-851-py3-none-linux_x86_64.whl',
+        f'nvblox_torch-{NVBLOX_VERSION_NUMBER}{NVBLOX_VERSION_PATCH}+cu12ubuntu22-863-py3-none-linux_x86_64.whl',
     'wheel_name_ubuntu_22_cuda_11': \
-        'nvblox_torch-0.0.8rc3+cu11ubuntu22-1user-py3-none-linux_x86_64.whl',
+        f'nvblox_torch-{NVBLOX_VERSION_NUMBER}{NVBLOX_VERSION_PATCH}+cu11ubuntu22-863-py3-none-linux_x86_64.whl',
+    'wheel_name_ubuntu_24_cuda_13': \
+        f'nvblox_torch-{NVBLOX_VERSION_NUMBER}{NVBLOX_VERSION_PATCH}+cu13ubuntu24-863-py3-none-linux_x86_64.whl',
     'internal_git_url': 'ssh://git@gitlab-master.nvidia.com:12051/nvblox/nvblox.git',
     'external_git_url': 'git@github.com:nvidia-isaac/nvblox.git',
     'internal_code_link_base_url': 'https://gitlab-master.nvidia.com/nvblox/nvblox/-/tree/main',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,12 +17,6 @@ from typing import List
 import os
 import sys
 
-# NOTE: sphinx-multiversion doesn't provide a reliable way to detect the version
-# at conf.py import time. We need to use the setup() function to access Sphinx config.
-# For now, set a placeholder that will be updated in setup().
-NVBLOX_VERSION_NUMBER = '0.0.8'    # Will be overridden in setup()
-NVBLOX_VERSION_PATCH = 'rc5'    # For v0.0.8
-
 
 # Define setup() function to properly detect version after Sphinx initializes
 # pylint: disable=import-outside-toplevel,broad-exception-caught
@@ -45,12 +39,7 @@ def setup(app: object) -> None:
         return f'nvblox_torch-{version}{patch}+cu{cuda}ubuntu{ubuntu}-863-py3-none-linux_x86_64.whl'
 
     def _update_version_config(version: str) -> None:
-        """Update all version-dependent configuration values."""
-        global NVBLOX_VERSION_NUMBER
-        NVBLOX_VERSION_NUMBER = version
-        app.config.html_title = f'nvblox_torch {NVBLOX_VERSION_NUMBER}'
-
-        # Update wheel URLs and names in nvblox_torch_docs_config
+        """Update version-dependent wheel URLs and names in config."""
         app.config.nvblox_torch_docs_config['external_wheel_base_url'] = \
             f'https://github.com/nvidia-isaac/nvblox/releases/download/v{version}'
         app.config.nvblox_torch_docs_config['wheel_name_ubuntu_24_cuda_12'] = \
@@ -162,7 +151,6 @@ nitpick_ignore: List[str] = []    # can exclude known bad refs
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'nvidia_sphinx_theme'
-html_title = f'nvblox_torch {NVBLOX_VERSION_NUMBER}'
 html_show_sphinx = False
 html_theme_options = {
     'copyright_override': {
@@ -214,16 +202,13 @@ nvblox_torch_docs_config = {
     'released': released,
     'internal_wheel_base_url': 'https://urm.nvidia.com/artifactory/hw-nvblox-alpine-local/' + \
         'pypi/release/nvblox_torch/',
-    'external_wheel_base_url': 'https://github.com/nvidia-isaac/nvblox/releases' + \
-        f'/download/v{NVBLOX_VERSION_NUMBER}',
-    'wheel_name_ubuntu_24_cuda_12': \
-        f'nvblox_torch-{NVBLOX_VERSION_NUMBER}{NVBLOX_VERSION_PATCH}+cu12ubuntu24-863-py3-none-linux_x86_64.whl',
-    'wheel_name_ubuntu_22_cuda_12': \
-        f'nvblox_torch-{NVBLOX_VERSION_NUMBER}{NVBLOX_VERSION_PATCH}+cu12ubuntu22-863-py3-none-linux_x86_64.whl',
-    'wheel_name_ubuntu_22_cuda_11': \
-        f'nvblox_torch-{NVBLOX_VERSION_NUMBER}{NVBLOX_VERSION_PATCH}+cu11ubuntu22-863-py3-none-linux_x86_64.whl',
-    'wheel_name_ubuntu_24_cuda_13': \
-        f'nvblox_torch-{NVBLOX_VERSION_NUMBER}{NVBLOX_VERSION_PATCH}+cu13ubuntu24-863-py3-none-linux_x86_64.whl',
+    # Note: external_wheel_base_url and wheel_name_* are updated by setup() function
+    # with version-specific values from each branch's setup.py file
+    'external_wheel_base_url': '',
+    'wheel_name_ubuntu_24_cuda_12': '',
+    'wheel_name_ubuntu_22_cuda_12': '',
+    'wheel_name_ubuntu_22_cuda_11': '',
+    'wheel_name_ubuntu_24_cuda_13': '',
     'internal_git_url': 'ssh://git@gitlab-master.nvidia.com:12051/nvblox/nvblox.git',
     'external_git_url': 'git@github.com:nvidia-isaac/nvblox.git',
     'internal_code_link_base_url': 'https://gitlab-master.nvidia.com/nvblox/nvblox/-/tree/main',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,10 +17,20 @@ from typing import List
 import os
 import sys
 
-# Modify PYTHONPATH so we can obtain the version data from setup module.
+# Modify PYTHONPATH so we can import the helpers module.
 # pylint: disable=wrong-import-position
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'nvblox_torch')))
-from setup import NVBLOX_VERSION_NUMBER, NVBLOX_VERSION_PATCH
+sys.path.insert(0, os.path.abspath('.'))
+from helpers import get_version_from_multiversion_env
+
+# NOTE: We use environment variables instead of importing from setup.py to avoid
+# Python module import caching issues with sphinx-multiversion. When building
+# multiple versions, the first import of 'setup' gets cached and reused for all
+# subsequent builds. Reading from SPHINX_MULTIVERSION_NAME env var ensures each
+# version build uses its correct version number.
+NVBLOX_VERSION_NUMBER = get_version_from_multiversion_env()
+
+# For v0.0.8, the version patch is 'rc5'
+NVBLOX_VERSION_PATCH = 'rc5'
 
 # NOTE(alexmillane, 2025-04-24): This file is in a seperate folder to avoid
 # duplicate configuration errors coming from mypy. The only way I could find
@@ -49,6 +59,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx_tabs.tabs',
     'sphinx_copybutton',
+    'sphinx_multiversion',
     # TODO(alexmillane, 2025-04-24): Try re-enabling this once we have pydocs generating.
     #    'autodocsumm'
     'nvblox_torch_doc_tools'
@@ -83,7 +94,7 @@ nitpick_ignore: List[str] = []    # can exclude known bad refs
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'nvidia_sphinx_theme'
-html_title = 'nvblox'
+html_title = f'nvblox_torch {NVBLOX_VERSION_NUMBER}'
 html_show_sphinx = False
 html_theme_options = {
     'copyright_override': {
@@ -109,6 +120,12 @@ html_theme_options = {
 # html_static_path = []
 html_static_path = ['_static']
 html_css_files = ['custom.css']
+
+# Versioning (sphinx-multiversion)
+smv_remote_whitelist = r'^.*$'
+smv_branch_whitelist = r'^(public|v0.0.8-docs|v0.0.9-docs)$'
+smv_tag_whitelist = r'^(v0.0.8|v0.0.9)$'
+html_sidebars = {'**': ['versioning.html', 'sidebar-nav-bs']}
 
 # Todos
 todo_include_todos = True

--- a/docs/helpers.py
+++ b/docs/helpers.py
@@ -35,7 +35,8 @@ def get_version_from_multiversion_env() -> str:
     """Get version number from sphinx-multiversion environment.
 
     When building with sphinx-multiversion, extract version from
-    SPHINX_MULTIVERSION_NAME environment variable (e.g., "v0.0.8" -> "0.0.8").
+    SPHINX_MULTIVERSION_NAME environment variable or from the checked-out
+    branch's setup.py file (e.g., "v0.0.8" -> "0.0.8").
 
     Falls back to reading from setup.py for local single-version builds.
 
@@ -47,10 +48,12 @@ def get_version_from_multiversion_env() -> str:
 
     # Debug output
     print(f'[VERSION DEBUG] SPHINX_MULTIVERSION_NAME = {smv_name}')
+    print(f'[VERSION DEBUG] Current directory: {os.getcwd()}')
+    print(f'[VERSION DEBUG] __file__ location: {os.path.abspath(__file__)}')
 
     if smv_name:
         # Parse version from branch/tag name
-        # Handles: "v0.0.8", "v0.0.9", with or without 'v' prefix
+        # Handles: "v0.0.8-docs", "v0.0.9-docs", with or without 'v' prefix
         match = re.match(r'v?(\d+\.\d+\.\d+)', smv_name)
         if match:
             version = match.group(1)
@@ -63,9 +66,11 @@ def get_version_from_multiversion_env() -> str:
             print(f'[VERSION DEBUG] Public branch, read from setup.py: {version}')
             return version
 
-    # Fallback for local builds (not using sphinx-multiversion)
+    # Fallback: read from setup.py in the current working directory
+    # When sphinx-multiversion builds, it checks out each version to a temp dir,
+    # so we should read from THAT version's setup.py
     version = _read_version_from_setup()
-    print(f'[VERSION DEBUG] No multiversion env, read from setup.py: {version}')
+    print(f'[VERSION DEBUG] Reading from setup.py: {version}')
     return version
 
 
@@ -73,14 +78,24 @@ def _read_version_from_setup() -> str:
     """Read version from setup.py by parsing file content.
 
     This avoids Python import caching issues.
+
+    Uses current working directory instead of __file__ location because
+    sphinx-multiversion changes CWD to the checked-out version's directory,
+    but __file__ still points to the original file location.
     """
-    setup_path = os.path.join(os.path.dirname(__file__), '..', 'nvblox_torch', 'setup.py')
+    # Use current working directory (which sphinx-multiversion sets correctly)
+    setup_path = os.path.join(os.getcwd(), '..', 'nvblox_torch', 'setup.py')
+    setup_path = os.path.abspath(setup_path)
+
+    print(f'[VERSION DEBUG] Reading version from: {setup_path}')
 
     with open(setup_path, 'r', encoding='utf-8') as f:
         content = f.read()
 
     match = re.search(r"NVBLOX_VERSION_NUMBER\s*=\s*['\"]([^'\"]+)['\"]", content)
     if match:
-        return match.group(1)
+        version = match.group(1)
+        print(f'[VERSION DEBUG] Found version in setup.py: {version}')
+        return version
 
     raise ValueError(f'Could not find NVBLOX_VERSION_NUMBER in {setup_path}')

--- a/docs/helpers.py
+++ b/docs/helpers.py
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+import dataclasses
+import datetime
+import os
+import re
+
+
+def to_datetime(date_str: str) -> datetime.datetime:
+    return datetime.datetime.strptime(date_str, '%d.%m.%Y')
+
+
+def is_expired(start_date: datetime.datetime, days: int) -> bool:
+    today = datetime.datetime.now()
+    delta = datetime.timedelta(days=days)
+    return today > (start_date + delta)
+
+
+@dataclasses.dataclass
+class TemporaryLinkcheckIgnore:
+    url: str
+    start_date: datetime.datetime
+    days: int
+
+
+def get_version_from_multiversion_env() -> str:
+    """Get version number from sphinx-multiversion environment.
+
+    When building with sphinx-multiversion, extract version from
+    SPHINX_MULTIVERSION_NAME environment variable (e.g., "v0.0.8" -> "0.0.8").
+
+    Falls back to reading from setup.py for local single-version builds.
+
+    Returns:
+        Version string like "0.0.8" or "0.0.9"
+    """
+    # Check if running under sphinx-multiversion
+    smv_name = os.environ.get('SPHINX_MULTIVERSION_NAME')
+
+    # Debug output
+    print(f'[VERSION DEBUG] SPHINX_MULTIVERSION_NAME = {smv_name}')
+
+    if smv_name:
+        # Parse version from branch/tag name
+        # Handles: "v0.0.8", "v0.0.9", with or without 'v' prefix
+        match = re.match(r'v?(\d+\.\d+\.\d+)', smv_name)
+        if match:
+            version = match.group(1)
+            print(f'[VERSION DEBUG] Extracted version from env: {version}')
+            return version
+
+        # For "public" branch, read from current setup.py
+        if smv_name == 'public':
+            version = _read_version_from_setup()
+            print(f'[VERSION DEBUG] Public branch, read from setup.py: {version}')
+            return version
+
+    # Fallback for local builds (not using sphinx-multiversion)
+    version = _read_version_from_setup()
+    print(f'[VERSION DEBUG] No multiversion env, read from setup.py: {version}')
+    return version
+
+
+def _read_version_from_setup() -> str:
+    """Read version from setup.py by parsing file content.
+
+    This avoids Python import caching issues.
+    """
+    setup_path = os.path.join(os.path.dirname(__file__), '..', 'nvblox_torch', 'setup.py')
+
+    with open(setup_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    match = re.search(r"NVBLOX_VERSION_NUMBER\s*=\s*['\"]([^'\"]+)['\"]", content)
+    if match:
+        return match.group(1)
+
+    raise ValueError(f'Could not find NVBLOX_VERSION_NUMBER in {setup_path}')


### PR DESCRIPTION
In https://github.com/nvidia-isaac/nvblox/pull/110 we fixed versioning in multiversion docs.
This MR backports necessary changes to v0.0.8 such that we can correctly retrieve the version number.