### PR TITLE
V0.0.9 docs version fix

### DIFF
--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -13,6 +13,7 @@ from typing import List, Any
 
 from sphinx.application import Sphinx
 
+UNKNOWN_VERSION = 'unknown'
 
 VERSION_TO_WHEEL_NAME = {
     '0.0.9': {
@@ -23,12 +24,13 @@ VERSION_TO_WHEEL_NAME = {
     }
 }
 
+WHEEL_BASE_URL = 'https://github.com/nvidia-isaac/nvblox/releases/download/'
 
 def get_wheel_url(version: str, cuda_version: str, ubuntu_version: str) -> str:
     """Get the wheel URL for a given version, CUDA version, and Ubuntu version.
 
     """
-    return f'https://github.com/nvidia-isaac/nvblox/releases/download/v{version}/nvblox_torch-{version}+cu{cuda_version}ubuntu{ubuntu_version}-py3-none-linux_x86_64.whl'
+    return f'{WHEEL_BASE_URL}v{version}/nvblox_torch-{version}+cu{cuda_version}ubuntu{ubuntu_version}-py3-none-linux_x86_64.whl'
 
 
 def get_smv_version_number(app: Sphinx) -> str:
@@ -36,10 +38,14 @@ def get_smv_version_number(app: Sphinx) -> str:
 
     """
     smv_current_version = getattr(app.config, 'smv_current_version', None)
-    if smv_current_version:
-        return re.search(r'v(\d+\.\d+\.\d+)', smv_current_version).group(1)
-    else:
-        raise ValueError('Failed to get current version number. Build with make multi-doc.')
+
+    # Extract 0.0.9 from branch name like v0.0.9-docs_test
+    match = re.search(r'v(\d+\.\d+\.\d+)', smv_current_version)
+    if not match:
+        return UNKNOWN_VERSION
+    version = match.group(1)
+
+    return version
 
 def nvblox_torch_pip_install_code_block(app: Sphinx, _: Any, source: List[str]) -> None:
     """Replaces the :nvblox_torch_pip_install_code_block: directive with a code block.
@@ -52,34 +58,21 @@ def nvblox_torch_pip_install_code_block(app: Sphinx, _: Any, source: List[str]) 
     def replacer(_: Any) -> str:
 
         version = get_smv_version_number(app)
-        release_state = app.config.nvblox_torch_docs_config['released']
-        internal_wheel_base_url = app.config.nvblox_torch_docs_config['internal_wheel_base_url']
-        external_wheel_base_url = app.config.nvblox_torch_docs_config['external_wheel_base_url']
+
         wheel_name_ubuntu_24_cuda_12 = get_wheel_url(version, '12', '24')
-        wheel_name_ubuntu_22_cuda_12 = app.config.nvblox_torch_docs_config[
-            'wheel_name_ubuntu_22_cuda_12']
-        wheel_name_ubuntu_22_cuda_11 = app.config.nvblox_torch_docs_config[
-            'wheel_name_ubuntu_22_cuda_11']
-        wheel_name_ubuntu_24_cuda_13 = app.config.nvblox_torch_docs_config[
-            'wheel_name_ubuntu_24_cuda_13']
-        if release_state:
-            pip_install_target_ubuntu_24_cuda_12 = \
-                f'{external_wheel_base_url}/{wheel_name_ubuntu_24_cuda_12}'
-            pip_install_target_ubuntu_22_cuda_12 = \
-                f'{external_wheel_base_url}/{wheel_name_ubuntu_22_cuda_12}'
-            pip_install_target_ubuntu_22_cuda_11 = \
-                f'{external_wheel_base_url}/{wheel_name_ubuntu_22_cuda_11}'
-            pip_install_target_ubuntu_24_cuda_13 = \
-                f'{external_wheel_base_url}/{wheel_name_ubuntu_24_cuda_13}'
-        else:
-            pip_install_target_ubuntu_24_cuda_12 = \
-                f'{internal_wheel_base_url}/{wheel_name_ubuntu_24_cuda_12}'
-            pip_install_target_ubuntu_22_cuda_12 = \
-                f'{internal_wheel_base_url}/{wheel_name_ubuntu_22_cuda_12}'
-            pip_install_target_ubuntu_22_cuda_11 = \
-                f'{internal_wheel_base_url}/{wheel_name_ubuntu_22_cuda_11}'
-            pip_install_target_ubuntu_24_cuda_13 = \
-                f'{internal_wheel_base_url}/{wheel_name_ubuntu_24_cuda_13}'
+        wheel_name_ubuntu_22_cuda_12 = get_wheel_url(version, '12', '22')
+        wheel_name_ubuntu_22_cuda_11 = get_wheel_url(version, '11', '22')
+        wheel_name_ubuntu_24_cuda_13 = get_wheel_url(version, '13', '24')
+        
+        pip_install_target_ubuntu_24_cuda_12 = \
+            f'{wheel_name_ubuntu_24_cuda_12}'
+        pip_install_target_ubuntu_22_cuda_12 = \
+            f'{wheel_name_ubuntu_22_cuda_12}'
+        pip_install_target_ubuntu_22_cuda_11 = \
+            f'{wheel_name_ubuntu_22_cuda_11}'
+        pip_install_target_ubuntu_24_cuda_13 = \
+            f'{wheel_name_ubuntu_24_cuda_13}'
+
         return f"""
 
 To install ``nvblox_torch`` via ``pip`` on a supported platform, run the following commands:

--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -79,7 +79,7 @@ def nvblox_torch_pip_install_code_block(app: Sphinx, _: Any, source: List[str]) 
         pip_install_target_ubuntu_24_cuda_13 = \
             f'{wheel_name_ubuntu_24_cuda_13}'
 
-        return f"""
+        rst_string = f"""
 
 To install ``nvblox_torch`` via ``pip`` on a supported platform, run the following commands:
 
@@ -104,7 +104,9 @@ To install ``nvblox_torch`` via ``pip`` on a supported platform, run the followi
 
             sudo apt-get install python3-pip libglib2.0-0 libgl1 # Open3D dependencies
             pip3 install {pip_install_target_ubuntu_22_cuda_11}
-
+"""
+        if version != '0.0.8':
+            rst_string += f"""
     .. tab:: Ubuntu 24.04 + CUDA 13.0
 
         .. code-block:: bash
@@ -114,6 +116,7 @@ To install ``nvblox_torch`` via ``pip`` on a supported platform, run the followi
             pip3 install {pip_install_target_ubuntu_24_cuda_13}
 
 """
+        return rst_string
     source[0] = re.sub(r':nvblox_torch_pip_install_code_block:', replacer, source[0])
 
 

--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -105,6 +105,8 @@ To install ``nvblox_torch`` via ``pip`` on a supported platform, run the followi
             sudo apt-get install python3-pip libglib2.0-0 libgl1 # Open3D dependencies
             pip3 install {pip_install_target_ubuntu_22_cuda_11}
 """
+        # Only add the CUDA 13.0 tab if the version is not 0.0.8.
+        # TODO(dtingdahl) handle this in a more elegant way to support future release configurations.
         if version != '0.0.8':
             rst_string += f"""
     .. tab:: Ubuntu 24.04 + CUDA 13.0

--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -15,23 +15,28 @@ from sphinx.application import Sphinx
 
 UNKNOWN_VERSION = 'unknown'
 
-VERSION_TO_WHEEL_NAME = {
-    '0.0.9': {
-        'ubuntu_24_cuda_12': 'nvblox_torch-0.0.9+cu12ubuntu24-py3-none-linux_x86_64.whl',
-        'ubuntu_22_cuda_12': 'nvblox_torch-0.0.9+cu12ubuntu22-py3-none-linux_x86_64.whl',
-        'ubuntu_22_cuda_11': 'nvblox_torch-0.0.9+cu11ubuntu22-py3-none-linux_x86_64.whl',
-        'ubuntu_24_cuda_13': 'nvblox_torch-0.0.9+cu13ubuntu24-py3-none-linux_x86_64.whl',
-    }
-}
 
-WHEEL_BASE_URL = 'https://github.com/nvidia-isaac/nvblox/releases/download/'
+WHEEL_BASE_URL = 'https://github.com/nvidia-isaac/nvblox/releases/download'
+
+
+
+def get_wheel_url_0_0_8(cuda_version: str, ubuntu_version: str) -> str:
+    """Get the wheel URL for version 0.0.8. It is a special case because it has build number in the wheen name.
+    """
+    return f'{WHEEL_BASE_URL}/v0.0.8/nvblox_torch-0.0.8rc5+cu{cuda_version}ubuntu{ubuntu_version}-863-py3-none-linux_x86_64.whl'
+
+def get_wheel_url_general(version: str, cuda_version: str, ubuntu_version: str) -> str:
+    """Get the wheel URL for a given version, CUDA version, and Ubuntu version.
+    """
+    return f'{WHEEL_BASE_URL}/v{version}/nvblox_torch-{version}+cu{cuda_version}ubuntu{ubuntu_version}-py3-none-linux_x86_64.whl'
 
 def get_wheel_url(version: str, cuda_version: str, ubuntu_version: str) -> str:
     """Get the wheel URL for a given version, CUDA version, and Ubuntu version.
-
     """
-    return f'{WHEEL_BASE_URL}v{version}/nvblox_torch-{version}+cu{cuda_version}ubuntu{ubuntu_version}-py3-none-linux_x86_64.whl'
-
+    if version == '0.0.8':
+        return get_wheel_url_0_0_8(cuda_version, ubuntu_version)
+    else:
+        return get_wheel_url_general(version, cuda_version, ubuntu_version)
 
 def get_smv_version_number(app: Sphinx) -> str:
     """Get the version number from the sphinx-multiversion current version.
@@ -63,6 +68,7 @@ def nvblox_torch_pip_install_code_block(app: Sphinx, _: Any, source: List[str]) 
         wheel_name_ubuntu_22_cuda_12 = get_wheel_url(version, '12', '22')
         wheel_name_ubuntu_22_cuda_11 = get_wheel_url(version, '11', '22')
         wheel_name_ubuntu_24_cuda_13 = get_wheel_url(version, '13', '24')
+
         
         pip_install_target_ubuntu_24_cuda_12 = \
             f'{wheel_name_ubuntu_24_cuda_12}'
@@ -108,7 +114,6 @@ To install ``nvblox_torch`` via ``pip`` on a supported platform, run the followi
             pip3 install {pip_install_target_ubuntu_24_cuda_13}
 
 """
-
     source[0] = re.sub(r':nvblox_torch_pip_install_code_block:', replacer, source[0])
 
 

--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -178,7 +178,13 @@ def current_version_name(app: Sphinx, _: Any, source: List[str]) -> None:
         # When sphinx-multiversion builds, it sets the 'smv_current_version' in the environment
         smv_current_version = getattr(app.config, 'smv_current_version', None)
         if smv_current_version:
-            return smv_current_version
+
+            # Extract version number from string containing v0.0.9
+            version = re.search(r'v(\d+\.\d+\.\d+)', smv_current_version)
+            if version:
+                return version.group(1)
+            else:
+                return 'unknown'
 
         # Fallback to the standard Sphinx version config
         version = getattr(app.config, 'version', None)

--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -15,20 +15,24 @@ from sphinx.application import Sphinx
 
 UNKNOWN_VERSION = 'unknown'
 
-
 WHEEL_BASE_URL = 'https://github.com/nvidia-isaac/nvblox/releases/download'
 
 
-
 def get_wheel_url_0_0_8(cuda_version: str, ubuntu_version: str) -> str:
-    """Get the wheel URL for version 0.0.8. It is a special case because it has build number in the wheen name.
+    """Get the wheel URL for version 0.0.8.
+
+    It is a special case because it has build number in the wheel filename.
     """
+    # pylint: disable=line-too-long
     return f'{WHEEL_BASE_URL}/v0.0.8/nvblox_torch-0.0.8rc5+cu{cuda_version}ubuntu{ubuntu_version}-863-py3-none-linux_x86_64.whl'
+
 
 def get_wheel_url_general(version: str, cuda_version: str, ubuntu_version: str) -> str:
     """Get the wheel URL for a given version, CUDA version, and Ubuntu version.
     """
+    # pylint: disable=line-too-long
     return f'{WHEEL_BASE_URL}/v{version}/nvblox_torch-{version}+cu{cuda_version}ubuntu{ubuntu_version}-py3-none-linux_x86_64.whl'
+
 
 def get_wheel_url(version: str, cuda_version: str, ubuntu_version: str) -> str:
     """Get the wheel URL for a given version, CUDA version, and Ubuntu version.
@@ -38,11 +42,14 @@ def get_wheel_url(version: str, cuda_version: str, ubuntu_version: str) -> str:
     else:
         return get_wheel_url_general(version, cuda_version, ubuntu_version)
 
+
 def get_smv_version_number(app: Sphinx) -> str:
     """Get the version number from the sphinx-multiversion current version.
 
     """
     smv_current_version = getattr(app.config, 'smv_current_version', None)
+    if smv_current_version is None:
+        return UNKNOWN_VERSION
 
     # Extract 0.0.9 from branch name like v0.0.9-docs_test
     match = re.search(r'v(\d+\.\d+\.\d+)', smv_current_version)
@@ -51,6 +58,7 @@ def get_smv_version_number(app: Sphinx) -> str:
     version = match.group(1)
 
     return version
+
 
 def nvblox_torch_pip_install_code_block(app: Sphinx, _: Any, source: List[str]) -> None:
     """Replaces the :nvblox_torch_pip_install_code_block: directive with a code block.
@@ -69,7 +77,7 @@ def nvblox_torch_pip_install_code_block(app: Sphinx, _: Any, source: List[str]) 
         wheel_name_ubuntu_22_cuda_11 = get_wheel_url(version, '11', '22')
         wheel_name_ubuntu_24_cuda_13 = get_wheel_url(version, '13', '24')
 
-        
+
         pip_install_target_ubuntu_24_cuda_12 = \
             f'{wheel_name_ubuntu_24_cuda_12}'
         pip_install_target_ubuntu_22_cuda_12 = \
@@ -106,7 +114,7 @@ To install ``nvblox_torch`` via ``pip`` on a supported platform, run the followi
             pip3 install {pip_install_target_ubuntu_22_cuda_11}
 """
         # Only add the CUDA 13.0 tab if the version is not 0.0.8.
-        # TODO(dtingdahl) handle this in a more elegant way to support future release configurations.
+        # TODO(dtingdahl) handle this in a more elegant way to support future releases.
         if version != '0.0.8':
             rst_string += f"""
     .. tab:: Ubuntu 24.04 + CUDA 13.0
@@ -119,6 +127,7 @@ To install ``nvblox_torch`` via ``pip`` on a supported platform, run the followi
 
 """
         return rst_string
+
     source[0] = re.sub(r':nvblox_torch_pip_install_code_block:', replacer, source[0])
 
 
@@ -215,7 +224,7 @@ def current_version_name(app: Sphinx, _: Any, source: List[str]) -> None:
             return version
         else:
             raise ValueError('Failed to get current version name. Build with make multi-doc.')
-        
+
     source[0] = re.sub(r':current_version_name:', replacer, source[0])
 
 

--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -14,6 +14,33 @@ from typing import List, Any
 from sphinx.application import Sphinx
 
 
+VERSION_TO_WHEEL_NAME = {
+    '0.0.9': {
+        'ubuntu_24_cuda_12': 'nvblox_torch-0.0.9+cu12ubuntu24-py3-none-linux_x86_64.whl',
+        'ubuntu_22_cuda_12': 'nvblox_torch-0.0.9+cu12ubuntu22-py3-none-linux_x86_64.whl',
+        'ubuntu_22_cuda_11': 'nvblox_torch-0.0.9+cu11ubuntu22-py3-none-linux_x86_64.whl',
+        'ubuntu_24_cuda_13': 'nvblox_torch-0.0.9+cu13ubuntu24-py3-none-linux_x86_64.whl',
+    }
+}
+
+
+def get_wheel_url(version: str, cuda_version: str, ubuntu_version: str) -> str:
+    """Get the wheel URL for a given version, CUDA version, and Ubuntu version.
+
+    """
+    return f'https://github.com/nvidia-isaac/nvblox/releases/download/v{version}/nvblox_torch-{version}+cu{cuda_version}ubuntu{ubuntu_version}-py3-none-linux_x86_64.whl'
+
+
+def get_smv_version_number(app: Sphinx) -> str:
+    """Get the version number from the sphinx-multiversion current version.
+
+    """
+    smv_current_version = getattr(app.config, 'smv_current_version', None)
+    if smv_current_version:
+        return re.search(r'v(\d+\.\d+\.\d+)', smv_current_version).group(1)
+    else:
+        raise ValueError('Failed to get current version number. Build with make multi-doc.')
+
 def nvblox_torch_pip_install_code_block(app: Sphinx, _: Any, source: List[str]) -> None:
     """Replaces the :nvblox_torch_pip_install_code_block: directive with a code block.
 
@@ -23,11 +50,12 @@ def nvblox_torch_pip_install_code_block(app: Sphinx, _: Any, source: List[str]) 
     """
 
     def replacer(_: Any) -> str:
+
+        version = get_smv_version_number(app)
         release_state = app.config.nvblox_torch_docs_config['released']
         internal_wheel_base_url = app.config.nvblox_torch_docs_config['internal_wheel_base_url']
         external_wheel_base_url = app.config.nvblox_torch_docs_config['external_wheel_base_url']
-        wheel_name_ubuntu_24_cuda_12 = app.config.nvblox_torch_docs_config[
-            'wheel_name_ubuntu_24_cuda_12']
+        wheel_name_ubuntu_24_cuda_12 = get_wheel_url(version, '12', '24')
         wheel_name_ubuntu_22_cuda_12 = app.config.nvblox_torch_docs_config[
             'wheel_name_ubuntu_22_cuda_12']
         wheel_name_ubuntu_22_cuda_11 = app.config.nvblox_torch_docs_config[
@@ -180,14 +208,11 @@ def current_version_name(app: Sphinx, _: Any, source: List[str]) -> None:
         if smv_current_version:
 
             # Extract version number from string containing v0.0.9
-            version = re.search(r'v(\d+\.\d+\.\d+)', smv_current_version)
-            if version:
-                return version.group(1)
-            else:
-                raise ValueError(f'Failed to extract version number from {smv_current_version}')
+            version = get_smv_version_number(app)
+            return version
         else:
             raise ValueError('Failed to get current version name. Build with make multi-doc.')
-
+        
     source[0] = re.sub(r':current_version_name:', replacer, source[0])
 
 

--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -162,9 +162,39 @@ def nvblox_code_link(app: Sphinx, _: Any, source: List[str]) -> None:
     source[0] = re.sub(r':nvblox_code_link:`<(?P<relative_path>.*)>`', replacer, source[0])
 
 
+def current_version_name(app: Sphinx, _: Any, source: List[str]) -> None:
+    """Replaces the :current_version_name: directive with the current version name.
+
+    This uses the sphinx-multiversion context if available, otherwise falls back
+    to the Sphinx version config value.
+
+    Usage in RST:
+        Current Version: :current_version_name:
+
+    """
+
+    def replacer(_: Any) -> str:
+        # Try to get the version from sphinx-multiversion's environment
+        # When sphinx-multiversion builds, it sets the 'smv_current_version' in the environment
+        smv_current_version = getattr(app.config, 'smv_current_version', None)
+        if smv_current_version:
+            return smv_current_version
+
+        # Fallback to the standard Sphinx version config
+        version = getattr(app.config, 'version', None)
+        if version:
+            return version
+
+        # Last resort fallback
+        return 'unknown'
+
+    source[0] = re.sub(r':current_version_name:', replacer, source[0])
+
+
 def setup(app: Sphinx) -> None:
     app.connect('source-read', nvblox_torch_pip_install_code_block)
     app.connect('source-read', nvblox_torch_git_clone_code_block)
     app.connect('source-read', nvblox_code_link)
     app.connect('source-read', download_test_dataset)
+    app.connect('source-read', current_version_name)
     app.add_config_value('nvblox_torch_docs_config', {}, 'env')

--- a/docs/_ext/nvblox_torch_doc_tools.py
+++ b/docs/_ext/nvblox_torch_doc_tools.py
@@ -184,15 +184,9 @@ def current_version_name(app: Sphinx, _: Any, source: List[str]) -> None:
             if version:
                 return version.group(1)
             else:
-                return 'unknown'
-
-        # Fallback to the standard Sphinx version config
-        version = getattr(app.config, 'version', None)
-        if version:
-            return version
-
-        # Last resort fallback
-        return 'unknown'
+                raise ValueError(f'Failed to extract version number from {smv_current_version}')
+        else:
+            raise ValueError('Failed to get current version name. Build with make multi-doc.')
 
     source[0] = re.sub(r':current_version_name:', replacer, source[0])
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,8 +118,8 @@ html_css_files = ['custom.css']
 
 # Versioning (sphinx-multiversion)
 smv_remote_whitelist = r'^.*$'
-smv_branch_whitelist = r'^(public|v0.0.8|v0.0.9)$'
-smv_tag_whitelist = r'^(v0.0.8|v0.0.9)$'
+smv_branch_whitelist = r'^(public|v0.0.8-docs_test|v0.0.9-docs_test)$'
+smv_tag_whitelist = r'^(v0.0.8-docs_test|v0.0.9-docs_test)$'
 html_sidebars = {'**': ['versioning.html', 'sidebar-nav-bs']}
 
 # Todos

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,8 +114,8 @@ html_css_files = ['custom.css']
 
 # Versioning (sphinx-multiversion)
 smv_remote_whitelist = r'^.*$'
-smv_branch_whitelist = r'^(public|v0.0.8-docs_test|v0.0.9-docs_test)$'
-smv_tag_whitelist = r'^(v0.0.8-docs_test|v0.0.9-docs_test)$'
+smv_branch_whitelist = r'^(public|v0.0.8|v0.0.9)$'
+smv_tag_whitelist = r'^(v0.0.8|v0.0.9)$'
 html_sidebars = {'**': ['versioning.html', 'sidebar-nav-bs']}
 
 # Todos

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,12 +18,8 @@ from typing import List
 import os
 import sys
 
-# Modify PYTHONPATH so we can obtain the version data from setup module.
-# pylint: disable=wrong-import-position
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'nvblox_torch')))
-from setup import NVBLOX_VERSION_NUMBER
-
 # Modify PYTHONPATH so we can import the helpers module.
+# pylint: disable=wrong-import-position
 sys.path.insert(0, os.path.abspath('.'))
 from helpers import TemporaryLinkcheckIgnore, to_datetime, is_expired
 
@@ -89,7 +85,7 @@ nitpick_ignore: List[str] = []    # can exclude known bad refs
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'nvidia_sphinx_theme'
-html_title = f'nvblox_torch {NVBLOX_VERSION_NUMBER}'
+html_title = 'nvblox'
 html_show_sphinx = False
 html_theme_options = {
     'copyright_override': {
@@ -158,18 +154,6 @@ for ignore in temporary_linkcheck_ignore:
 
 nvblox_torch_docs_config = {
     'released': released,
-    'internal_wheel_base_url': 'https://urm.nvidia.com/artifactory/hw-nvblox-alpine-local/' + \
-        'pypi/release/nvblox_torch/',
-    'external_wheel_base_url': 'https://github.com/nvidia-isaac/nvblox/releases' + \
-        f'/download/v{NVBLOX_VERSION_NUMBER}',
-    'wheel_name_ubuntu_24_cuda_12': \
-        'nvblox_torch-0.0.9.dev1+cu12ubuntu24-py3-none-linux_x86_64.whl',
-    'wheel_name_ubuntu_22_cuda_12': \
-        'nvblox_torch-0.0.9.dev1+cu12ubuntu22-py3-none-linux_x86_64.whl',
-    'wheel_name_ubuntu_22_cuda_11': \
-        'nvblox_torch-0.0.9.dev1+cu11ubuntu22-py3-none-linux_x86_64.whl',
-    'wheel_name_ubuntu_24_cuda_13': \
-        'nvblox_torch-0.0.9.dev1+cu13ubuntu24-py3-none-linux_x86_64.whl',
     'internal_git_url': 'ssh://git@gitlab-master.nvidia.com:12051/nvblox/nvblox.git',
     'external_git_url': 'git@github.com:nvidia-isaac/nvblox.git',
     'internal_code_link_base_url': 'https://gitlab-master.nvidia.com/nvblox/nvblox/-/tree/main',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Depending on your use-case, you may interact with ``nvblox`` through either Pyth
 Quickstart
 ==========
 
+Current Version: :current_version_name:
 
 :nvblox_torch_pip_install_code_block:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,6 @@ Depending on your use-case, you may interact with ``nvblox`` through either Pyth
 Quickstart
 ==========
 
-Current Version: :current_version_name:
 
 :nvblox_torch_pip_install_code_block:
 


### PR DESCRIPTION
Fix versioning for wheels. 

using VERSION_NUMBER from setup.py caused 0.0.9 to appear also for 0.0.8. Now we obtain the version from sphinx, which comes from the branch name we build the docs from