### PR TITLE
Build on Orin in public CI

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -4,6 +4,9 @@ inputs:
   platform:
     description: 'Platform to build for'
     required: true
+  cuda-arch:
+    description: 'CUDA architecture'
+    required: true
   cuda-version:
     description: 'CUDA version'
     required: true
@@ -44,7 +47,7 @@ runs:
       shell: bash
       run: |
         # Store arguments used for all jobs in an environment variable.
-        echo "COMMON_NVBLOX_CI_ARGS=--platform ${{ inputs.platform }} --cuda-version ${{ inputs.cuda-version }} --ubuntu-version ${{ inputs.ubuntu-version }} --gcc-sanitizer ${{ inputs.gcc-sanitizer }}" >> $GITHUB_ENV
+        echo "COMMON_NVBLOX_CI_ARGS=--platform ${{ inputs.platform }} --cuda-arch ${{ inputs.cuda-arch }} --cuda-version ${{ inputs.cuda-version }} --ubuntu-version ${{ inputs.ubuntu-version }} --gcc-sanitizer ${{ inputs.gcc-sanitizer }}" >> $GITHUB_ENV
     # Note that the two build-image steps could be omitted since the build-and-test steps also build necessary images.
     # However, we separate the steps to get cleaner logs and better timing granularity.
     - name: Build dependency image

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -134,25 +134,26 @@ jobs:
   ## ------------------------------------------
   ## Build and test Thor
   ## ------------------------------------------
-  premerge_thor_jetpack7:
-    name: Build&Test thor-jetpack7
-    needs: [lint_precommit]
-    runs-on: [self-hosted, jetson-thor]
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-      - name: premerge_thor_jetpack7 - Unit tests
-        uses: ./.github/actions/build-and-test
-        with:
-          platform: jetpack7
-          cuda-version: '12' # unused
-          ubuntu-version: '24' # unused
-          cuda-arch: '110' # Native detection of sm-arch not supported on thor.
-          ngc-api-key: ${{ secrets.NGC_API_KEY }}
-          run-realsense-tests: false
-          run-cuda-sanitizer: false
+  # TODO(dtingdahl) Enable once Thor is supported.
+  # premerge_thor_jetpack7:
+  #   name: Build&Test thor-jetpack7
+  #   needs: [lint_precommit]
+  #   runs-on: [self-hosted, jetson-thor]
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         lfs: true
+  #     - name: premerge_thor_jetpack7 - Unit tests
+  #       uses: ./.github/actions/build-and-test
+  #       with:
+  #         platform: jetpack7
+  #         cuda-version: '12' # unused
+  #         ubuntu-version: '24' # unused
+  #         cuda-arch: '110' # Native detection of sm-arch not supported on thor.
+  #         ngc-api-key: ${{ secrets.NGC_API_KEY }}
+  #         run-realsense-tests: false
+  #         run-cuda-sanitizer: false
   ## --------------------------------------------------------
   ## Build docs
   ## --------------------------------------------------------

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -39,6 +39,7 @@ jobs:
         uses: ./.github/actions/build-and-test
         with:
           platform: x86_64
+          cuda-arch: 'native'
           cuda-version: '11'
           ubuntu-version: '22'
           ngc-api-key: ${{ secrets.NGC_API_KEY }}
@@ -58,6 +59,7 @@ jobs:
         uses: ./.github/actions/build-and-test
         with:
           platform: x86_64
+          cuda-arch: 'native'
           cuda-version: '12'
           ubuntu-version: '22'
           ngc-api-key: ${{ secrets.NGC_API_KEY }}
@@ -77,6 +79,7 @@ jobs:
         uses: ./.github/actions/build-and-test
         with:
           platform: x86_64
+          cuda-arch: 'native'
           cuda-version: '13'
           ubuntu-version: '24'
           ngc-api-key: ${{ secrets.NGC_API_KEY }}
@@ -97,6 +100,7 @@ jobs:
         uses: ./.github/actions/build-and-test
         with:
           platform: x86_64
+          cuda-arch: 'native'
           cuda-version: '12'
           ubuntu-version: '22'
           gcc-sanitizer: 1
@@ -104,6 +108,50 @@ jobs:
           run-python-tests: false # TODO(dtingdahl) Enable these tests
           run-realsense-tests: false #
           run-cuda-sanitizer: false #
+  ## ------------------------------------------
+  ## Build and test Orin
+  ## ------------------------------------------
+  premerge_orin_jetpack6:
+    name: Build&Test orin-jetpack6
+    needs: [lint_precommit]
+    runs-on: [self-hosted, jetson-orin, jetpack-6.2]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: premerge_orin_jetpack6 - Unit tests
+        uses: ./.github/actions/build-and-test
+        with:
+          platform: jetpack6
+          cuda-version: '12' # unused
+          ubuntu-version: '22' # unused
+          cuda-arch: '87' # Native detection of sm-arch not supported on orin.
+          ngc-api-key: ${{ secrets.NGC_API_KEY }}
+          run-realsense-tests: false
+          run-cuda-sanitizer: false
+  ## ------------------------------------------
+  ## Build and test Thor
+  ## ------------------------------------------
+  premerge_thor_jetpack7:
+    name: Build&Test thor-jetpack7
+    needs: [lint_precommit]
+    runs-on: [self-hosted, jetson-thor]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: premerge_thor_jetpack7 - Unit tests
+        uses: ./.github/actions/build-and-test
+        with:
+          platform: jetpack7
+          cuda-version: '12' # unused
+          ubuntu-version: '24' # unused
+          cuda-arch: '110' # Native detection of sm-arch not supported on thor.
+          ngc-api-key: ${{ secrets.NGC_API_KEY }}
+          run-realsense-tests: false
+          run-cuda-sanitizer: false
   ## --------------------------------------------------------
   ## Build docs
   ## --------------------------------------------------------

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -42,6 +42,7 @@ jobs:
           cuda-arch: 'native'
           cuda-version: '11'
           ubuntu-version: '22'
+          run-realsense-tests: false # CuvSLAM unsupported for CUDA 11.
           ngc-api-key: ${{ secrets.NGC_API_KEY }}
   ## ------------------------------------------
   ## Build and test x86/CU12/U22

--- a/ci/ci_utils.py
+++ b/ci/ci_utils.py
@@ -348,7 +348,7 @@ class OsImage(DockerImage):
         },
         Platform.JETPACK_6: {
             CudaVersion.CUDA_12: {
-                UbuntuVersion.UBUNTU_22: 'nvcr.io/nvidia/l4t-jetpack:r36.4.0'
+                UbuntuVersion.UBUNTU_22: 'nvcr.io/nvidia/l4t-jetpack:r36.3.0'
             }
         },
     }

--- a/ci/ci_utils.py
+++ b/ci/ci_utils.py
@@ -21,6 +21,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List, Optional, Tuple
 import re
+import pprint
 
 
 class Platform(Enum):
@@ -311,7 +312,10 @@ class TestBase(ABC):
     def run(self) -> None:
         """Build image and run command inside it"""
         self.image().build()
-        docker_cmd = ['docker', 'run', '--privileged', '--rm', self.image().image_name()]
+        docker_cmd = [
+            'docker', 'run', '--privileged', '--runtime=nvidia', '--rm',
+            self.image().image_name()
+        ]
         cwd = self.get_cwd()
         cmd = self.get_command()
         full_cmd = docker_cmd + ['bash', '-c'] + [f'cd {cwd} && {cmd}']
@@ -337,8 +341,16 @@ class OsImage(DockerImage):
                 UbuntuVersion.UBUNTU_24: 'nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04',
             },
         },
-        Platform.JETPACK_5: 'nvcr.io/nvidia/l4t-jetpack:r35.4.1',
-        Platform.JETPACK_6: 'nvcr.io/nvidia/l4t-jetpack:r36.3.0',
+        Platform.JETPACK_5: {
+            CudaVersion.CUDA_11: {
+                UbuntuVersion.UBUNTU_22: 'nvcr.io/nvidia/l4t-jetpack:r35.4.1'
+            }
+        },
+        Platform.JETPACK_6: {
+            CudaVersion.CUDA_12: {
+                UbuntuVersion.UBUNTU_22: 'nvcr.io/nvidia/l4t-jetpack:r36.4.0'
+            }
+        },
     }
 
     def get_os_image_name(self) -> str:
@@ -348,7 +360,9 @@ class OsImage(DockerImage):
         if os_image is None:
             raise ValueError(f'No OS image available for platform {self.args.platform}, '
                              f'cuda version {self.args.cuda_version}, '
-                             f'and ubuntu version {self.args.ubuntu_version}')
+                             f'and ubuntu version {self.args.ubuntu_version}.\n'
+                             f'Available images:\n'
+                             f'{pprint.pformat(self.AVAILABLE_OS_IMAGES, indent=2)}')
         return os_image
 
     def image_name(self) -> str:

--- a/ci/nvblox_ci.py
+++ b/ci/nvblox_ci.py
@@ -126,7 +126,7 @@ class CppUnitTests(TestBase):
 
     def get_command(self) -> str:
         num_jobs = self.args.max_num_jobs
-        base_cmd = f'ctest -j{num_jobs} -T test ' f'--no-compress-output'
+        base_cmd = f'ctest -j{num_jobs} -T test --no-compress-output --output-on-failure'
 
         # When running tests with gcc sanitizers, we need to disable address space
         # randomization due to bug in libgcc that appears on certain platforms.

--- a/ci/system_info.py
+++ b/ci/system_info.py
@@ -160,6 +160,35 @@ def print_system_info() -> None:
         except (OSError, subprocess.SubprocessError, ValueError) as e:
             return [f'Failed to run nvidia-smi: {e}']
 
+    def _uname_lines() -> List[str]:
+        try:
+            result = subprocess.run(
+                ['uname', '-a'],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.stdout:
+                return [result.stdout.strip()]
+            err = (result.stderr or '').strip()
+            return [err or 'uname -a returned no output.']
+        except subprocess.TimeoutExpired:
+            return ['uname -a timed out.']
+        except (OSError, subprocess.SubprocessError, ValueError) as e:
+            return [f'Failed to run uname -a: {e}']
+
+    def _l4t_lines() -> List[str]:
+        nv_path = '/etc/nv_tegra_release'
+        if os.path.exists(nv_path):
+            try:
+                with open(nv_path, 'r', encoding='utf-8') as f:
+                    lines = [line.strip() for line in f if line.strip()]
+                return lines if lines else [f'{nv_path} is present but empty.']
+            except (OSError, IOError) as e:
+                return [f'Found {nv_path} but failed to read: {e}']
+        return [f'{nv_path} not present (likely non-Jetson).']
+
     # System section
     os_info = _read_os_release() or {}
     pretty_name = os_info.get('PRETTY_NAME')
@@ -180,6 +209,10 @@ def print_system_info() -> None:
         f'Num CPUs:   {os.cpu_count()}',
     ]
     _print_section('System Information', system_lines)
+
+    # Kernel / L4T sections
+    _print_section('Kernel (uname -a)', _uname_lines())
+    _print_section('Jetson L4T (nv_tegra_release)', _l4t_lines())
 
     # Memory section
     _print_section('Memory', _memory_lines())

--- a/docker/Dockerfile.jetson_deps
+++ b/docker/Dockerfile.jetson_deps
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvcr.io/nvidia/l4t-jetpack:r36.3.0
+ARG BASE_IMAGE=nvcr.io/nvidia/l4t-jetpack:r36.4.0
 FROM ${BASE_IMAGE}
 
 # TZData goes first.

--- a/docker/Dockerfile.jetson_deps
+++ b/docker/Dockerfile.jetson_deps
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvcr.io/nvidia/l4t-jetpack:r36.4.0
+ARG BASE_IMAGE=nvcr.io/nvidia/l4t-jetpack:r36.3.0
 FROM ${BASE_IMAGE}
 
 # TZData goes first.

--- a/docker/Dockerfile.realsense_example
+++ b/docker/Dockerfile.realsense_example
@@ -19,8 +19,6 @@ RUN apt update && apt-get --no-install-recommends install -y \
 RUN . /opt/venv/bin/activate && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install \
-        # Nvblox is installed from the build directory
-        /nvblox/nvblox_torch \
         # Other dependencies for the realsense example
         pyrealsense2 \
         rerun-sdk

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -83,7 +83,7 @@ PYTORCH_VERSIONS = [
     PytorchVersion(
         platform='aarch64',
         cuda_version='12',
-        pytorch_version='2.9.1',
+        pytorch_version='2.3.0',
         _pytorch_url='https://nvidia.box.com/shared/static/mp164asf3sceb570wvjsrezk1p4ftj8t.whl',
         pytorch_filename='torch-2.3.0-cp310-cp310-linux_aarch64.whl',
     # pylint: disable=line-too-long

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -76,7 +76,7 @@ def get_cuda_version() -> str:
     return match.group(1).split('.')[0]
 
 
-def get_pytorch_version_for_this_machine() -> PytorchVersion:
+def get_pytorch_version_for_this_machine() -> PytorchVersion | None:
     """Get the pytorch version for the current system or None if not supported."""
 
     print(f'platform.machine(): {platform.machine()}')
@@ -87,9 +87,9 @@ def get_pytorch_version_for_this_machine() -> PytorchVersion:
         if v.platform == platform.machine() and v.cuda_version == get_cuda_version()
     ]
 
-    if result is None:
+    if not result:
         print(f'No pytorch version found for {platform.machine()} '
-              'with cuda version: {get_cuda_version()}')
+              f'with cuda version: {get_cuda_version()}')
         return None
     print(f'pytorch version: {result}')
     assert len(result) <= 1, 'Expected 1 pytorch version'
@@ -100,7 +100,7 @@ def install_pytorch_if_supported_for_this_machine() -> None:
 
     pytorch_version = get_pytorch_version_for_this_machine()
     if pytorch_version is None:
-        print('Warning: pytorch not supported on this system')
+        print('pytorch not supported on this system')
         return
 
     script = f"""
@@ -123,7 +123,7 @@ def install_nvblox_torch_if_supported_for_this_machine() -> None:
 
     pytorch_version = get_pytorch_version_for_this_machine()
     if pytorch_version is None:
-        print('Warning: nvblox torch not supported on this system')
+        print('nvblox torch not supported on this system')
         return
 
     script = f"""

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -16,6 +16,7 @@ import platform
 import argparse
 from dataclasses import dataclass
 from typing import Optional
+import sys
 
 
 @dataclass
@@ -25,8 +26,22 @@ class PytorchVersion:
     cuda_version: str
 
     pytorch_version: str
-    pytorch_url: str
-    torchvision_url: Optional[str] = None    # Only needed for jetson.
+    _pytorch_url: str
+    _torchvision_url: Optional[str] = None    # Only needed for jetson.
+
+    def python_version(self) -> str:
+        """Return python version string like cp312"""
+        return f'cp{sys.version_info.major}{sys.version_info.minor}'
+
+    def pytorch_url(self) -> str:
+        """URL depends on the current python version"""
+        return self._pytorch_url.replace('PY', self.python_version())
+
+    def torchvision_url(self) -> Optional[str]:
+        """URL depends on the current python version"""
+        if self._torchvision_url is None:
+            return None
+        return self._torchvision_url.replace('PY', self.python_version())
 
 
 # List of supported pytorch versions in this project.
@@ -35,36 +50,36 @@ PYTORCH_VERSIONS = [
         platform='x86_64',
         cuda_version='11',
         pytorch_version='2.7.1',
-        pytorch_url=
+        _pytorch_url=
     # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu118/torch-2.7.1%2Bcu118-cp310-cp310-manylinux_2_28_x86_64.whl'
+        'https://download.pytorch.org/whl/cu118/torch-2.7.1%2Bcu118-PY-PY-manylinux_2_28_x86_64.whl'
     ),
     PytorchVersion(
         platform='x86_64',
         cuda_version='12',
         pytorch_version='2.9.1',
-        pytorch_url=
+        _pytorch_url=
     # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl'
+        'https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-PY-PY-manylinux_2_28_x86_64.whl'
     ),
     PytorchVersion(
         platform='x86_64',
         cuda_version='13',
         pytorch_version='2.9.1',
-        pytorch_url=
+        _pytorch_url=
     # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl'
+        'https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-PY-PY-manylinux_2_28_x86_64.whl'
     ),
     PytorchVersion(
         platform='aarch64',
         cuda_version='12',
         pytorch_version='2.9.1',
-        pytorch_url=
+        _pytorch_url=
     # pylint: disable=line-too-long
-        'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/02f/de421eabbf626/torch-2.9.1-cp310-cp310-linux_aarch64.whl',
-        torchvision_url=
+        'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/02f/de421eabbf626/torch-2.9.1-PY-PY-linux_aarch64.whl',
+        _torchvision_url=
     # pylint: disable=line-too-long
-        'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/d5b/caaf709f11750/torchvision-0.24.1-cp310-cp310-linux_aarch64.whl'
+        'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/d5b/caaf709f11750/torchvision-0.24.1-PY-PY-linux_aarch64.whl'
     ),
 ]
 
@@ -111,12 +126,12 @@ def install_pytorch_if_supported_for_this_machine() -> None:
     umask 000
     . /opt/venv/bin/activate
     python3 -m pip install --ignore-installed --upgrade pip --no-cache-dir
-    python3 -m pip install --no-cache-dir {pytorch_version.pytorch_url}
+    python3 -m pip install --no-cache-dir {pytorch_version.pytorch_url()}
     """
 
     if pytorch_version.torchvision_url is not None:
         script += f"""
-        python3 -m pip install --no-cache-dir {pytorch_version.torchvision_url}
+        python3 -m pip install --no-cache-dir {pytorch_version.torchvision_url()}
         """
 
     subprocess.run(script, shell=True, check=True)

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -16,84 +16,64 @@ import platform
 import argparse
 from dataclasses import dataclass
 from typing import Optional
-import sys
 
 
 @dataclass
-class PytorchVersion:
+class TorchVersion:
     """Store information of a pythorch version."""
 
     platform: str
     cuda_version: str
 
     pytorch_version: str
-    _pytorch_url: str
+    torchvision_version: str
+    index_url: Optional[str] = None
 
     # Special treatment needed for Jetson:
-    # * Need to explicitly install torchvision
+    # * Need to explicitly install urls.
     # * Wheel urls has to be renamed to be installable. Hence we need the filename as well
-    _torchvision_url: Optional[str] = None
+    # TODO(dtingdahl): Remove these variables by using the pip install method described on
+    #  https://docs.nvidia.com/deeplearning/frameworks/install-pytorch-jetson-platform/index.html.
+    #  So far, this method cause linkage errors in our containers due to wrong version of cuDNN.
+    pytorch_url: Optional[str] = None
+    torchvision_url: Optional[str] = None
     torchvision_filename: Optional[str] = None
     pytorch_filename: Optional[str] = None
 
-    def python_version(self) -> str:
-        """Return python version string like cp312"""
-        return f'cp{sys.version_info.major}{sys.version_info.minor}'
-
-    def pytorch_url(self) -> str:
-        """URL depends on the current python version"""
-        return self._pytorch_url.replace('PY', self.python_version())
-
-    def torchvision_url(self) -> Optional[str]:
-        """URL depends on the current python version"""
-        if self._torchvision_url is None:
-            return None
-        return self._torchvision_url.replace('PY', self.python_version())
-
 
 # List of supported pytorch versions in this project.
-PYTORCH_VERSIONS = [
-    PytorchVersion(
+TORCH_VERSIONS = [
+    TorchVersion(
         platform='x86_64',
         cuda_version='11',
-        pytorch_version='2.7.1',
-        _pytorch_url=
-    # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu118/torch-2.7.1%2Bcu118-PY-PY-manylinux_2_28_x86_64.whl',
-    # pylint: disable=line-too-long
-        _torchvision_url=
-        'https://download.pytorch.org/whl/cu118/torchvision-0.22.0%2Bcu118-PY-PY-manylinux_2_28_x86_64.whl',
+        index_url='https://download.pytorch.org/whl/cu118',
+        pytorch_version='2.7.0',
+        torchvision_version='0.22.0',
     ),
-    PytorchVersion(
+    TorchVersion(
         platform='x86_64',
         cuda_version='12',
+        index_url='https://download.pytorch.org/whl/cu128',
         pytorch_version='2.9.1',
-        _pytorch_url=
-    # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-PY-PY-manylinux_2_28_x86_64.whl',
-    # pylint: disable=line-too-long
-        _torchvision_url=
-        'https://download.pytorch.org/whl/cu128/torchvision-0.24.1%2Bcu128-PY-PY-manylinux_2_28_x86_64.whl',
+        torchvision_version='0.24.1',
     ),
-    PytorchVersion(
+    TorchVersion(
         platform='x86_64',
         cuda_version='13',
+        index_url='https://download.pytorch.org/whl/cu130',
         pytorch_version='2.9.1',
-        _pytorch_url=
-    # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-PY-PY-manylinux_2_28_x86_64.whl',
-        _torchvision_url=
-    # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-PY-PY-manylinux_2_28_x86_64.whl',
+        torchvision_version='0.24.1',
     ),
-    PytorchVersion(
+    TorchVersion(
         platform='aarch64',
         cuda_version='12',
         pytorch_version='2.3.0',
-        _pytorch_url='https://nvidia.box.com/shared/static/mp164asf3sceb570wvjsrezk1p4ftj8t.whl',
+        torchvision_version='0.18.0',
+    # pylint: disable=line-too-long
+        pytorch_url='https://nvidia.box.com/shared/static/mp164asf3sceb570wvjsrezk1p4ftj8t.whl',
         pytorch_filename='torch-2.3.0-cp310-cp310-linux_aarch64.whl',
     # pylint: disable=line-too-long
-        _torchvision_url='https://nvidia.box.com/shared/static/xpr06qe6ql3l6rj22cu3c45tz1wzi36p.whl',
+        torchvision_url='https://nvidia.box.com/shared/static/xpr06qe6ql3l6rj22cu3c45tz1wzi36p.whl',
         torchvision_filename='torchvision-0.18.0-cp310-cp310-linux_aarch64.whl',
     ),
 ]
@@ -109,14 +89,14 @@ def get_cuda_version() -> str:
     return match.group(1).split('.')[0]
 
 
-def get_pytorch_version_for_this_machine() -> Optional[PytorchVersion]:
+def get_pytorch_version_for_this_machine() -> Optional[TorchVersion]:
     """Get the pytorch version for the current system or None if not supported."""
 
     print(f'platform.machine(): {platform.machine()}')
     print(f'get_cuda_version(): {get_cuda_version()}')
 
     result = [
-        v for v in PYTORCH_VERSIONS
+        v for v in TORCH_VERSIONS
         if v.platform == platform.machine() and v.cuda_version == get_cuda_version()
     ]
 
@@ -149,24 +129,28 @@ def install_pytorch_if_supported_for_this_machine() -> None:
     pip install --ignore-installed --upgrade pip --no-cache-dir
     """
 
-    pytorch_url = pytorch_version.pytorch_url()
-    torchvision_url = pytorch_version.torchvision_url()
+    if pytorch_version.platform == 'x86_64':
+        script += f"""
+            pip install \
+                --no-cache-dir \
+                --index-url {pytorch_version.index_url} \
+                torch=={pytorch_version.pytorch_version} \
+                torchvision=={pytorch_version.torchvision_version}
+            """
+    else:
+        # If on aarch64, we need to download the wheel blob and rename it.
+        # Otherwise pip won't install it.
+        assert pytorch_version.pytorch_filename is not None
+        assert pytorch_version.torchvision_filename is not None
+        pytorch_file = download_and_rename_wheel(pytorch_version.pytorch_url,
+                                                 pytorch_version.pytorch_filename)
+        torchvision_file = download_and_rename_wheel(pytorch_version.torchvision_url,
+                                                     pytorch_version.torchvision_filename)
 
-    # If explicit filename is provided, we need to download the wheel and rename it
-    # since the url is not installable.
-    if pytorch_version.pytorch_filename:
-        download_and_rename_wheel(pytorch_version.pytorch_url(), pytorch_version.pytorch_filename)
-        pytorch_url = pytorch_version.pytorch_filename
-    if pytorch_version.torchvision_filename:
-        download_and_rename_wheel(pytorch_version.torchvision_url(),
-                                  pytorch_version.torchvision_filename)
-        torchvision_url = pytorch_version.torchvision_filename
-
-    # Add snippet to install torch and torchvision.
-    script += f"""
-        pip install --no-cache-dir {pytorch_url}
-        pip install --no-cache-dir {torchvision_url}
-        """
+        script += f"""
+            pip install --no-cache-dir {pytorch_file}
+            pip install --no-cache-dir {torchvision_file}
+            """
 
     subprocess.run(script, shell=True, check=True)
 

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -30,18 +30,30 @@ class PytorchVersion:
 
 # List of supported pytorch versions in this project.
 PYTORCH_VERSIONS = [
-    PytorchVersion(platform='x86',
-                   cuda_version='11',
-                   pytorch_version='2.7.1',
-                   pytorch_url='https://download.pytorch.org/whl/cu118/torch/'),
-    PytorchVersion(platform='x86',
-                   cuda_version='12',
-                   pytorch_version='2.9.1',
-                   pytorch_url='https://download.pytorch.org/whl/cu128/torch/'),
-    PytorchVersion(platform='x86',
-                   cuda_version='13',
-                   pytorch_version='2.9.1',
-                   pytorch_url='https://download.pytorch.org/whl/cu130/torch/'),
+    PytorchVersion(
+        platform='x86_64',
+        cuda_version='11',
+        pytorch_version='2.7.1',
+        pytorch_url=
+    # pylint: disable=line-too-long
+        'https://download.pytorch.org/whl/cu118/torch-2.7.1%2Bcu118-cp310-cp310-manylinux_2_28_x86_64.whl'
+    ),
+    PytorchVersion(
+        platform='x86_64',
+        cuda_version='12',
+        pytorch_version='2.9.1',
+        pytorch_url=
+    # pylint: disable=line-too-long
+        'https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl'
+    ),
+    PytorchVersion(
+        platform='x86_64',
+        cuda_version='13',
+        pytorch_version='2.9.1',
+        pytorch_url=
+    # pylint: disable=line-too-long
+        'https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl'
+    ),
     PytorchVersion(
         platform='aarch64',
         cuda_version='12',
@@ -66,18 +78,29 @@ def get_cuda_version() -> str:
 
 def get_pytorch_version_for_this_machine() -> PytorchVersion:
     """Get the pytorch version for the current system or None if not supported."""
-    return next(pytorch_version for pytorch_version in PYTORCH_VERSIONS
-                if pytorch_version.platform == platform.machine()
-                and pytorch_version.cuda_version == get_cuda_version())
+
+    print(f'platform.machine(): {platform.machine()}')
+    print(f'get_cuda_version(): {get_cuda_version()}')
+
+    result = [
+        v for v in PYTORCH_VERSIONS
+        if v.platform == platform.machine() and v.cuda_version == get_cuda_version()
+    ]
+
+    if result is None:
+        print(f'No pytorch version found for {platform.machine()} '
+              'with cuda version: {get_cuda_version()}')
+        return None
+    print(f'pytorch version: {result}')
+    assert len(result) <= 1, 'Expected 1 pytorch version'
+    return result[0]
 
 
 def install_pytorch_if_supported_for_this_machine() -> None:
 
     pytorch_version = get_pytorch_version_for_this_machine()
     if pytorch_version is None:
-        cuda_version = get_cuda_version()
-        print(f'Warning: pytorch not supported on this system: '
-              f'{platform.machine()} with cuda version: {cuda_version}')
+        print('Warning: pytorch not supported on this system')
         return
 
     script = f"""
@@ -85,12 +108,12 @@ def install_pytorch_if_supported_for_this_machine() -> None:
     umask 000
     . /opt/venv/bin/activate
     python3 -m pip install --ignore-installed --upgrade pip --no-cache-dir
-    python3 -m pip install --no-cache-dir {PytorchVersion.pytorch_url}
+    python3 -m pip install --no-cache-dir {pytorch_version.pytorch_url}
     """
 
-    if PytorchVersion.torchvision_url is not None:
+    if pytorch_version.torchvision_url is not None:
         script += f"""
-        python3 -m pip install --no-cache-dir {PytorchVersion.torchvision_url}
+        python3 -m pip install --no-cache-dir {pytorch_version.torchvision_url}
         """
 
     subprocess.run(script, shell=True, check=True)
@@ -100,18 +123,16 @@ def install_nvblox_torch_if_supported_for_this_machine() -> None:
 
     pytorch_version = get_pytorch_version_for_this_machine()
     if pytorch_version is None:
-        cuda_version = get_cuda_version()
-        print(f'Warning: nvblox torch not supported on this system: '
-              f'{platform.machine()} with cuda version: {cuda_version}')
+        print('Warning: nvblox torch not supported on this system')
         return
 
-    script = """
+    script = f"""
     set -ex
     umask 000
     . /opt/venv/bin/activate
     python3 -m pip install --ignore-installed --upgrade pip --no-cache-dir
     # Need to force the torch version to prevent accidental upgrades.
-    pip install /nvblox/nvblox_torch/ "torch=={pytorch_version.pytorch_version}"'
+    pip install /nvblox/nvblox_torch/ torch=={pytorch_version.pytorch_version}
     """
 
     subprocess.run(script, shell=True, check=True)

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -15,6 +15,7 @@ import re
 import platform
 import argparse
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -25,7 +26,7 @@ class PytorchVersion:
 
     pytorch_version: str
     pytorch_url: str
-    torchvision_url: str | None = None    # Only needed for jetson.
+    torchvision_url: Optional[str] = None    # Only needed for jetson.
 
 
 # List of supported pytorch versions in this project.
@@ -57,8 +58,10 @@ PYTORCH_VERSIONS = [
     PytorchVersion(
         platform='aarch64',
         cuda_version='12',
-        pytorch_version='2.3.0',
-        pytorch_url='https://nvidia.box.com/shared/static/xpr06qe6ql3l6rj22cu3c45tz1wzi36p.whl',
+        pytorch_version='2.9.1',
+        pytorch_url=
+    # pylint: disable=line-too-long
+        'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/02f/de421eabbf626/torch-2.9.1-cp310-cp310-linux_aarch64.whl',
         torchvision_url=
     # pylint: disable=line-too-long
         'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/d5b/caaf709f11750/torchvision-0.24.1-cp310-cp310-linux_aarch64.whl'
@@ -76,7 +79,7 @@ def get_cuda_version() -> str:
     return match.group(1).split('.')[0]
 
 
-def get_pytorch_version_for_this_machine() -> PytorchVersion | None:
+def get_pytorch_version_for_this_machine() -> Optional[PytorchVersion]:
     """Get the pytorch version for the current system or None if not supported."""
 
     print(f'platform.machine(): {platform.machine()}')

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -14,32 +14,44 @@ import subprocess
 import re
 import platform
 import argparse
+from dataclasses import dataclass
 
-# pylint: disable=line-too-long
-X86_CUDA_VERSION_TO_PYTORCH_PIP_URL = {
-    # Latest version of pytorch compatible with CUDA 11
-    '11': '--index-url https://download.pytorch.org/whl/cu118/torch/ --extra-index-url https://pypi.org/simple torch==2.7.1',
-    # Default pypi version uses CUDA 12
-    '12': 'torch==2.9.1',
-    '13': '--index-url https://download.pytorch.org/whl/cu130/torch/ --extra-index-url https://pypi.org/simple torch==2.9.1',
-}
 
-# We currently only support Jetpack 6 (Cuda12) for jetson. These are nvidia-hosted builds of JP6 wheels.
-JETSON_CUDA_VERSION_TO_TORCH = {
-    '12': {
-        'url': 'https://nvidia.box.com/shared/static/mp164asf3sceb570wvjsrezk1p4ftj8t.whl',
-        'filename': 'torch-2.3.0-cp310-cp310-linux_aarch64.whl'
-    },
-}
+@dataclass
+class PytorchVersion:
+    """Store information of a pythorch version."""
+    platform: str
+    cuda_version: str
 
-# On Jetson we also need to explicitly install torchvision.
-JETSON_CUDA_VERSION_TO_TORCHVISION = {
-    '12': {
-        'url': 'https://nvidia.box.com/shared/static/xpr06qe6ql3l6rj22cu3c45tz1wzi36p.whl',
-        'filename': 'torchvision-0.18.0-cp310-cp310-linux_aarch64.whl'
-    },
-}
-# pylint: enable=line-too-long
+    pytorch_version: str
+    pytorch_url: str
+    torchvision_url: str | None = None    # Only needed for jetson.
+
+
+# List of supported pytorch versions in this project.
+PYTORCH_VERSIONS = [
+    PytorchVersion(platform='x86',
+                   cuda_version='11',
+                   pytorch_version='2.7.1',
+                   pytorch_url='https://download.pytorch.org/whl/cu118/torch/'),
+    PytorchVersion(platform='x86',
+                   cuda_version='12',
+                   pytorch_version='2.9.1',
+                   pytorch_url='https://download.pytorch.org/whl/cu128/torch/'),
+    PytorchVersion(platform='x86',
+                   cuda_version='13',
+                   pytorch_version='2.9.1',
+                   pytorch_url='https://download.pytorch.org/whl/cu130/torch/'),
+    PytorchVersion(
+        platform='aarch64',
+        cuda_version='12',
+        pytorch_version='2.3.0',
+        pytorch_url='https://nvidia.box.com/shared/static/xpr06qe6ql3l6rj22cu3c45tz1wzi36p.whl',
+        torchvision_url=
+    # pylint: disable=line-too-long
+        'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/d5b/caaf709f11750/torchvision-0.24.1-cp310-cp310-linux_aarch64.whl'
+    ),
+]
 
 
 def get_cuda_version() -> str:
@@ -52,60 +64,45 @@ def get_cuda_version() -> str:
     return match.group(1).split('.')[0]
 
 
-def install_pytorch_x86() -> None:
-
-    cuda_version = get_cuda_version()
-    if cuda_version not in X86_CUDA_VERSION_TO_PYTORCH_PIP_URL:
-        raise ValueError(f'Unsupported CUDA version: {cuda_version}')
-
-    pytorch_install = X86_CUDA_VERSION_TO_PYTORCH_PIP_URL[cuda_version]
-    print(f'installing pytorch from {pytorch_install}')
-
-    script = f"""
-    set -ex
-    umask 000
-    . /opt/venv/bin/activate
-    python3 -m pip install --ignore-installed --upgrade pip --no-cache-dir
-    python3 -m pip install --no-cache-dir {pytorch_install}
-    """
-
-    subprocess.run(script, shell=True, check=True)
+def get_pytorch_version_for_this_machine() -> PytorchVersion:
+    """Get the pytorch version for the current system or None if not supported."""
+    return next(pytorch_version for pytorch_version in PYTORCH_VERSIONS
+                if pytorch_version.platform == platform.machine()
+                and pytorch_version.cuda_version == get_cuda_version())
 
 
-def install_pytorch_jetson() -> None:
+def install_pytorch_if_supported_for_this_machine() -> None:
 
-    cuda_version = get_cuda_version()
-    if cuda_version not in JETSON_CUDA_VERSION_TO_TORCH:
-        print('warning: Unsupported CUDA version: {cuda_version}. Skipping pytorch installation.')
+    pytorch_version = get_pytorch_version_for_this_machine()
+    if pytorch_version is None:
+        cuda_version = get_cuda_version()
+        print(f'Warning: pytorch not supported on this system: '
+              f'{platform.machine()} with cuda version: {cuda_version}')
         return
 
-    torch_url = JETSON_CUDA_VERSION_TO_TORCH[cuda_version]['url']
-    torch_filename = JETSON_CUDA_VERSION_TO_TORCH[cuda_version]['filename']
-    torchvision_url = JETSON_CUDA_VERSION_TO_TORCHVISION[cuda_version]['url']
-    torchvision_filename = JETSON_CUDA_VERSION_TO_TORCHVISION[cuda_version]['filename']
-
     script = f"""
     set -ex
     umask 000
     . /opt/venv/bin/activate
     python3 -m pip install --ignore-installed --upgrade pip --no-cache-dir
-    wget {torch_url} -O  /{torch_filename}
-    pip install /{torch_filename}
-    rm /{torch_filename}
-    wget {torchvision_url} -O /{torchvision_filename}
-    pip install /{torchvision_filename}
-    rm /{torchvision_filename}
+    python3 -m pip install --no-cache-dir {PytorchVersion.pytorch_url}
     """
+
+    if PytorchVersion.torchvision_url is not None:
+        script += f"""
+        python3 -m pip install --no-cache-dir {PytorchVersion.torchvision_url}
+        """
+
     subprocess.run(script, shell=True, check=True)
 
 
-def install_nvblox_torch() -> None:
+def install_nvblox_torch_if_supported_for_this_machine() -> None:
 
-    cuda_version = get_cuda_version()
-    supported_cuda_versions = list(JETSON_CUDA_VERSION_TO_TORCH.keys()
-                                   | X86_CUDA_VERSION_TO_PYTORCH_PIP_URL.keys())
-    if cuda_version not in supported_cuda_versions:
-        print(f'warning: Unsupported CUDA version: {cuda_version}. Skipping nvblox torch install.')
+    pytorch_version = get_pytorch_version_for_this_machine()
+    if pytorch_version is None:
+        cuda_version = get_cuda_version()
+        print(f'Warning: nvblox torch not supported on this system: '
+              f'{platform.machine()} with cuda version: {cuda_version}')
         return
 
     script = """
@@ -113,12 +110,10 @@ def install_nvblox_torch() -> None:
     umask 000
     . /opt/venv/bin/activate
     python3 -m pip install --ignore-installed --upgrade pip --no-cache-dir
+    # Need to force the torch version to prevent accidental upgrades.
+    pip install /nvblox/nvblox_torch/ "torch=={pytorch_version.pytorch_version}"'
     """
-    # Need to force the torch version for cuda 11 to prevent upgrade.
-    if cuda_version == '11':
-        script += 'pip install /nvblox/nvblox_torch/ "torch==2.7.1"'
-    else:
-        script += 'pip install /nvblox/nvblox_torch/'
+
     subprocess.run(script, shell=True, check=True)
 
 
@@ -147,16 +142,10 @@ def main() -> None:
      CUDA version (12 at the time of writing). Therefore we need this custom install script.
     """
     args = parse_args()
-
     if args.install_pytorch_if_supported:
-        if platform.machine() == 'x86_64':
-            install_pytorch_x86()
-        elif platform.machine() == 'aarch64':    # Jetson
-            install_pytorch_jetson()
-        else:
-            raise ValueError(f'Unsupported system: {platform.machine()}')
-    elif args.install_nvblox_torch_if_supported:
-        install_nvblox_torch()
+        install_pytorch_if_supported_for_this_machine()
+    if args.install_nvblox_torch_if_supported:
+        install_nvblox_torch_if_supported_for_this_machine()
 
 
 if __name__ == '__main__':

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -76,6 +76,9 @@ PYTORCH_VERSIONS = [
         _pytorch_url=
     # pylint: disable=line-too-long
         'https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-PY-PY-manylinux_2_28_x86_64.whl',
+        _torchvision_url=
+    # pylint: disable=line-too-long
+        'https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-PY-PY-manylinux_2_28_x86_64.whl',
     ),
     PytorchVersion(
         platform='aarch64',

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -22,12 +22,19 @@ import sys
 @dataclass
 class PytorchVersion:
     """Store information of a pythorch version."""
+
     platform: str
     cuda_version: str
 
     pytorch_version: str
     _pytorch_url: str
-    _torchvision_url: Optional[str] = None    # Only needed for jetson.
+
+    # Special treatment needed for Jetson:
+    # * Need to explicitly install torchvision
+    # * Wheel urls has to be renamed to be installable. Hence we need the filename as well
+    _torchvision_url: Optional[str] = None
+    torchvision_filename: Optional[str] = None
+    pytorch_filename: Optional[str] = None
 
     def python_version(self) -> str:
         """Return python version string like cp312"""
@@ -52,7 +59,7 @@ PYTORCH_VERSIONS = [
         pytorch_version='2.7.1',
         _pytorch_url=
     # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu118/torch-2.7.1%2Bcu118-PY-PY-manylinux_2_28_x86_64.whl'
+        'https://download.pytorch.org/whl/cu118/torch-2.7.1%2Bcu118-PY-PY-manylinux_2_28_x86_64.whl',
     ),
     PytorchVersion(
         platform='x86_64',
@@ -60,7 +67,7 @@ PYTORCH_VERSIONS = [
         pytorch_version='2.9.1',
         _pytorch_url=
     # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-PY-PY-manylinux_2_28_x86_64.whl'
+        'https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-PY-PY-manylinux_2_28_x86_64.whl',
     ),
     PytorchVersion(
         platform='x86_64',
@@ -68,18 +75,17 @@ PYTORCH_VERSIONS = [
         pytorch_version='2.9.1',
         _pytorch_url=
     # pylint: disable=line-too-long
-        'https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-PY-PY-manylinux_2_28_x86_64.whl'
+        'https://download.pytorch.org/whl/cu130/torch-2.9.1%2Bcu130-PY-PY-manylinux_2_28_x86_64.whl',
     ),
     PytorchVersion(
         platform='aarch64',
         cuda_version='12',
         pytorch_version='2.9.1',
-        _pytorch_url=
+        _pytorch_url='https://nvidia.box.com/shared/static/mp164asf3sceb570wvjsrezk1p4ftj8t.whl',
+        pytorch_filename='torch-2.3.0-cp310-cp310-linux_aarch64.whl',
     # pylint: disable=line-too-long
-        'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/02f/de421eabbf626/torch-2.9.1-PY-PY-linux_aarch64.whl',
-        _torchvision_url=
-    # pylint: disable=line-too-long
-        'https://pypi.jetson-ai-lab.io/jp6/cu126/+f/d5b/caaf709f11750/torchvision-0.24.1-PY-PY-linux_aarch64.whl'
+        _torchvision_url='https://nvidia.box.com/shared/static/xpr06qe6ql3l6rj22cu3c45tz1wzi36p.whl',
+        torchvision_filename='torchvision-0.18.0-cp310-cp310-linux_aarch64.whl',
     ),
 ]
 
@@ -114,6 +120,12 @@ def get_pytorch_version_for_this_machine() -> Optional[PytorchVersion]:
     return result[0]
 
 
+def download_and_rename_wheel(url: Optional[str], filename: Optional[str]) -> Optional[str]:
+    """Download the wheel and rename it"""
+    subprocess.run(f'wget {url} -O {filename}', shell=True, check=True)
+    return filename
+
+
 def install_pytorch_if_supported_for_this_machine() -> None:
 
     pytorch_version = get_pytorch_version_for_this_machine()
@@ -121,17 +133,36 @@ def install_pytorch_if_supported_for_this_machine() -> None:
         print('pytorch not supported on this system')
         return
 
-    script = f"""
+    script = """
     set -ex
     umask 000
     . /opt/venv/bin/activate
-    python3 -m pip install --ignore-installed --upgrade pip --no-cache-dir
-    python3 -m pip install --no-cache-dir {pytorch_version.pytorch_url()}
+    pip install --ignore-installed --upgrade pip --no-cache-dir
     """
 
-    if pytorch_version.torchvision_url is not None:
+    pytorch_url = pytorch_version.pytorch_url()
+    opt_torchvision_url = pytorch_version.torchvision_url()
+
+    # If explicit filename is provided, we need to download the wheel and rename it
+    # since the url is not installable.
+    if pytorch_version.pytorch_filename:
+        download_and_rename_wheel(pytorch_version.pytorch_url(), pytorch_version.pytorch_filename)
+        pytorch_url = pytorch_version.pytorch_filename
+
+    if pytorch_version.torchvision_filename:
+        download_and_rename_wheel(pytorch_version.torchvision_url(),
+                                  pytorch_version.torchvision_filename)
+        opt_torchvision_url = pytorch_version.torchvision_filename
+
+    # Add snippet to install torch.
+    script += f"""
+        pip install --no-cache-dir {pytorch_url}
+        """
+
+    # optionally add snippet to install torchvision
+    if opt_torchvision_url:
         script += f"""
-        python3 -m pip install --no-cache-dir {pytorch_version.torchvision_url()}
+        pip install --no-cache-dir {opt_torchvision_url}
         """
 
     subprocess.run(script, shell=True, check=True)
@@ -148,7 +179,7 @@ def install_nvblox_torch_if_supported_for_this_machine() -> None:
     set -ex
     umask 000
     . /opt/venv/bin/activate
-    python3 -m pip install --ignore-installed --upgrade pip --no-cache-dir
+    pip install --ignore-installed --upgrade pip --no-cache-dir
     # Need to force the torch version to prevent accidental upgrades.
     pip install /nvblox/nvblox_torch/ torch=={pytorch_version.pytorch_version}
     """
@@ -158,16 +189,20 @@ def install_nvblox_torch_if_supported_for_this_machine() -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--install-nvblox-torch-if-supported',
-                        action='store_true',
-                        help='Install nvblox torch if supported')
-    parser.add_argument('--install-pytorch-if-supported',
-                        action='store_true',
-                        help='Install pytorch if supported')
+    parser.add_argument(
+        '--install-nvblox-torch-if-supported',
+        action='store_true',
+        help='Install nvblox torch if supported',
+    )
+    parser.add_argument(
+        '--install-pytorch-if-supported',
+        action='store_true',
+        help='Install pytorch if supported',
+    )
 
     args = parser.parse_args()
 
-    if not args.install_pytorch_if_supported and not args.install_nvblox_torch_if_supported:
+    if (not args.install_pytorch_if_supported and not args.install_nvblox_torch_if_supported):
         parser.error('Either --install-pytorch-if-supported or '
                      '--install-nvblox-torch-if-supported must be provided')
 
@@ -177,8 +212,8 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     """Platform dependent installation of pytorch and nvblox torch.
 
-     Note that the pypi version of pytorch is locked to a specific
-     CUDA version (12 at the time of writing). Therefore we need this custom install script.
+    Note that the pypi version of pytorch is locked to a specific
+    CUDA version (12 at the time of writing). Therefore we need this custom install script.
     """
     args = parse_args()
     if args.install_pytorch_if_supported:

--- a/docker/torch_install_helper.py
+++ b/docker/torch_install_helper.py
@@ -60,6 +60,9 @@ PYTORCH_VERSIONS = [
         _pytorch_url=
     # pylint: disable=line-too-long
         'https://download.pytorch.org/whl/cu118/torch-2.7.1%2Bcu118-PY-PY-manylinux_2_28_x86_64.whl',
+    # pylint: disable=line-too-long
+        _torchvision_url=
+        'https://download.pytorch.org/whl/cu118/torchvision-0.22.0%2Bcu118-PY-PY-manylinux_2_28_x86_64.whl',
     ),
     PytorchVersion(
         platform='x86_64',
@@ -68,6 +71,9 @@ PYTORCH_VERSIONS = [
         _pytorch_url=
     # pylint: disable=line-too-long
         'https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-PY-PY-manylinux_2_28_x86_64.whl',
+    # pylint: disable=line-too-long
+        _torchvision_url=
+        'https://download.pytorch.org/whl/cu128/torchvision-0.24.1%2Bcu128-PY-PY-manylinux_2_28_x86_64.whl',
     ),
     PytorchVersion(
         platform='x86_64',
@@ -144,28 +150,22 @@ def install_pytorch_if_supported_for_this_machine() -> None:
     """
 
     pytorch_url = pytorch_version.pytorch_url()
-    opt_torchvision_url = pytorch_version.torchvision_url()
+    torchvision_url = pytorch_version.torchvision_url()
 
     # If explicit filename is provided, we need to download the wheel and rename it
     # since the url is not installable.
     if pytorch_version.pytorch_filename:
         download_and_rename_wheel(pytorch_version.pytorch_url(), pytorch_version.pytorch_filename)
         pytorch_url = pytorch_version.pytorch_filename
-
     if pytorch_version.torchvision_filename:
         download_and_rename_wheel(pytorch_version.torchvision_url(),
                                   pytorch_version.torchvision_filename)
-        opt_torchvision_url = pytorch_version.torchvision_filename
+        torchvision_url = pytorch_version.torchvision_filename
 
-    # Add snippet to install torch.
+    # Add snippet to install torch and torchvision.
     script += f"""
         pip install --no-cache-dir {pytorch_url}
-        """
-
-    # optionally add snippet to install torchvision
-    if opt_torchvision_url:
-        script += f"""
-        pip install --no-cache-dir {opt_torchvision_url}
+        pip install --no-cache-dir {torchvision_url}
         """
 
     subprocess.run(script, shell=True, check=True)


### PR DESCRIPTION
Enable CI for Jetson/Orin

* Require cuda sm-arch input since it can't be detected automatically on Orin
* Add missing runtime=nvidia to docker run
* Fix bug when determining base image based on platform and cuda version
* Add system info print on l4t version
* print-on-error for cmake tests