### PR TITLE
fix: image move constructor passes wrong stride unit to base constructor

### DIFF
--- a/nvblox/include/nvblox/sensors/internal/impl/image_impl.h
+++ b/nvblox/include/nvblox/sensors/internal/impl/image_impl.h
@@ -34,8 +34,7 @@ Image<ElementType>::Image(int rows, int cols, MemoryType memory_type)
 
 template <typename ElementType>
 Image<ElementType>::Image(Image<ElementType>&& other)
-    : ImageBase<ElementType>(other.rows_, other.cols_,
-                             other.stride_num_elements_,
+    : ImageBase<ElementType>(other.rows_, other.cols_, other.stride_bytes(),
                              other.num_elements_per_pixel_, other.data_),
       memory_type_(other.memory_type()),
       owned_data_(std::move(other.owned_data_)) {


### PR DESCRIPTION
Closes #118

This debug assertion in `Image` could be hit:

https://github.com/nvidia-isaac/nvblox/blob/48aa18ac374aa8b621ec6d6c3d3f1fb73b7dcab4/nvblox/include/nvblox/sensors/image.h#L186-L191

, because for the constructor [`ImageBase::ImageBase(int rows, int cols, int stride_bytes, 
                               int num_elements_per_pixel, 
                               OtherElementType* data)`](https://github.com/nvidia-isaac/nvblox/blob/48aa18ac374aa8b621ec6d6c3d3f1fb73b7dcab4/nvblox/include/nvblox/sensors/image.h#L195-L203) the `Image` move constructor passed the stride in number of elements instead of number bytes.

The fix is straightforward: pass the strides in numbers of bytes instead of numbers of elements on that call.

