### PR TITLE
Copy from strided depth image

### DIFF
--- a/nvblox/include/nvblox/core/internal/impl/unified_vector_impl.h
+++ b/nvblox/include/nvblox/core/internal/impl/unified_vector_impl.h
@@ -126,6 +126,22 @@ void unified_vector<T>::copyFromAsync(const T_noextent* const raw_ptr,
 }
 
 template <typename T>
+void unified_vector<T>::copyFromAsync2D(const T_noextent* const raw_ptr,
+                                      const size_t s_stride_num_elements,
+                                      const size_t d_stride_num_elements,
+                                      const size_t row,
+                                      const size_t col,
+                                      const CudaStream& cuda_stream) {
+  resizeAsync(row * d_stride_num_elements, cuda_stream);
+  if (raw_ptr != nullptr) {
+    checkCudaErrors(cudaMemcpy2DAsync(buffer_, sizeof(T) * d_stride_num_elements, 
+                                      raw_ptr, sizeof(T) * s_stride_num_elements, 
+                                      sizeof(T) * col, row,
+                                      cudaMemcpyDefault, cuda_stream));
+  }
+}
+
+template <typename T>
 void unified_vector<T>::copyToAsync(T_noextent* raw_ptr,
                                     const CudaStream& cuda_stream) const {
   CHECK(raw_ptr != nullptr);

--- a/nvblox/include/nvblox/core/unified_vector.h
+++ b/nvblox/include/nvblox/core/unified_vector.h
@@ -77,6 +77,12 @@ class unified_vector {
                      const CudaStream& cuda_stream);
   void copyFromAsync(const T_noextent* const raw_ptr, const size_t num_elements,
                      const CudaStream& cuda_stream);
+  void copyFromAsync2D(const T_noextent* const raw_ptr,
+                        const size_t s_stride_num_elements,
+                        const size_t d_stride_num_elements,
+                        const size_t row,
+                        const size_t col,
+                        const CudaStream& cuda_stream); 
 
   /// Copy to a raw pointer.
   void copyToAsync(T_noextent* raw_ptr, const CudaStream& cuda_stream) const;

--- a/nvblox/include/nvblox/sensors/image.h
+++ b/nvblox/include/nvblox/sensors/image.h
@@ -293,6 +293,12 @@ class Image : public ImageBase<_ElementType> {
                      const size_t num_elements_per_pixel,
                      const ElementType* const buffer,
                      const CudaStream& cuda_stream);
+  void copyFromAsync2D(const size_t rows, const size_t cols,
+                      const size_t stride_num_elements,
+                      const size_t buffer_stride_num_elements,
+                      const size_t num_elements_per_pixel,
+                      const ElementType* const buffer,
+                      const CudaStream& cuda_stream);
   void copyFrom(const size_t rows, const size_t cols,
                 const size_t stride_num_elements,
                 const size_t num_elements_per_pixel,

--- a/nvblox/include/nvblox/sensors/internal/impl/image_impl.h
+++ b/nvblox/include/nvblox/sensors/internal/impl/image_impl.h
@@ -124,6 +124,27 @@ void Image<ElementType>::copyFromAsync(const size_t rows, const size_t cols,
 }
 
 template <typename ElementType>
+void Image<ElementType>::copyFromAsync2D(const size_t rows, const size_t cols,
+                                       const size_t stride_num_elements,
+                                       const size_t buffer_stride_num_elements,
+                                       const size_t num_elements_per_pixel,
+                                       const ElementType* const buffer,
+                                       const CudaStream& cuda_stream) {
+  this->rows_ = rows;
+  this->cols_ = cols;
+  this->stride_num_elements_ = stride_num_elements;
+  this->num_elements_per_pixel_ = num_elements_per_pixel;
+
+  owned_data_.copyFromAsync2D(
+      buffer, 
+      buffer_stride_num_elements * num_elements_per_pixel, 
+      stride_num_elements * num_elements_per_pixel, 
+      rows, cols,
+      cuda_stream);
+  ImageBase<ElementType>::data_ = owned_data_.data();
+}
+
+template <typename ElementType>
 void Image<ElementType>::copyToAsync(ElementType* buffer,
                                      const CudaStream& cuda_stream) const {
   CHECK_NOTNULL(buffer);


### PR DESCRIPTION
Currently nvblox::Image::copyFromAsync does not allow copying from strided source depth image. This is an issue because source depth images will be strided as it allows much faster copy and is cuda kernel friendly. This commit adds  copyFromAsync2D overloaded with buffer_stride_num_elements, specifying input buffer stride. 